### PR TITLE
fix: pre-push hook should validate only branch commits

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -17,17 +17,14 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     continue
   fi
 
-  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
-    # New branch or new remote ref.
-    if git show-ref --verify --quiet "refs/remotes/$base_branch"; then
-      base_sha="$(git merge-base "$local_sha" "$base_branch")"
-      range="$base_sha..$local_sha"
-    else
-      # Fallback: validate just the tip commit (best effort)
-      range="$local_sha^..$local_sha"
-    fi
+  # Always validate only the commits on the branch that are *not* already in origin/main.
+  # This avoids re-validating commits that exist on main (even if a branch was rebased/force-pushed).
+  if git show-ref --verify --quiet "refs/remotes/$base_branch"; then
+    base_sha="$(git merge-base "$local_sha" "$base_branch")"
+    range="$base_sha..$local_sha"
   else
-    range="$remote_sha..$local_sha"
+    # Fallback: validate just the tip commit (best effort)
+    range="$local_sha^..$local_sha"
   fi
 
   "$validator" --range "$range"


### PR DESCRIPTION
### Problem
Rebasing a branch onto `origin/main` can cause the pre-push hook to validate commits that are already on `origin/main`. If a commit on main doesn't match the current commit-message rules, *any* rebased branch push can fail even though the developer isn't introducing that commit.

### Fix
Update `.githooks/pre-push` to always validate only commits reachable from the branch tip that are **not** already in `origin/main` (using merge-base).

### Impact
- Keeps the strict commit-message policy for new commits
- Avoids false failures on rebase/force-push workflows
- Maintains "no merge commits" policy (merge commits still fail `commit-msg`)
