### PR TITLE
fix: repair agent mention relay workflow yaml parsing

### DIFF
--- a/.github/workflows/agent-mention-relay.yml
+++ b/.github/workflows/agent-mention-relay.yml
@@ -27,30 +27,35 @@ jobs:
           BODY: ${{ github.event.comment.body }}
         run: |
           python3 - <<'PY'
-          import json, os
-          msg = f"""You were mentioned on GitHub.
+          import json
+          import os
 
-Repo: {os.getenv('REPO')}
-URL: {os.getenv('URL')}
-Author: @{os.getenv('AUTHOR')}
+          lines = [
+              "You were mentioned on GitHub.",
+              "",
+              f"Repo: {os.getenv('REPO')}",
+              f"URL: {os.getenv('URL')}",
+              f"Author: @{os.getenv('AUTHOR')}",
+              "",
+              "Comment:",
+              os.getenv('BODY') or "",
+              "",
+              "Task:",
+              "- Answer the user.",
+              "- Reply in the same GitHub thread using gh CLI.",
+              "- Keep it concise and practical.",
+          ]
 
-Comment:
-{os.getenv('BODY')}
-
-Task:
-- Answer the user.
-- Reply in the same GitHub thread using gh CLI.
-- Keep it concise and practical.
-"""
           payload = {
-            "name": "GitHub",
-            "agentId": "main",
-            "wakeMode": "now",
-            "deliver": False,
-            "message": msg,
+              "name": "GitHub",
+              "agentId": "main",
+              "wakeMode": "now",
+              "deliver": False,
+              "message": "\n".join(lines),
           }
-          with open("payload.json", "w") as f:
-            json.dump(payload, f)
+
+          with open("payload.json", "w", encoding="utf-8") as f:
+              json.dump(payload, f)
           PY
 
       - name: Relay request


### PR DESCRIPTION
## Problem
The newly merged relay workflow failed to load due to YAML syntax parsing in the multiline Python string block.

## What changed
- Rewrote payload construction script so all lines stay safely inside the `run` block.
- Kept security model unchanged:
  - actor allowlist
  - association allowlist
  - secret-based relay URL/token
  - `curl --fail-with-body`

## Validation
- Workflow file now parses correctly.

@HSILA please review.
