### PR TITLE
fix: unblock frontend production build

### DIFF
--- a/frontend/src/lib/api/cards.ts
+++ b/frontend/src/lib/api/cards.ts
@@ -137,7 +137,7 @@ function parseNextStatesResponse(value: unknown): NextStatesResponse {
   assertSchedulingInfo(value.hard, "Next states.hard");
   assertSchedulingInfo(value.good, "Next states.good");
   assertSchedulingInfo(value.easy, "Next states.easy");
-  return value as NextStatesResponse;
+  return value as unknown as NextStatesResponse;
 }
 
 function parseReviewResponse(value: unknown): ReviewResponse {


### PR DESCRIPTION
## Summary
Fixes TypeScript error blocking production build:

```
Type error: Conversion of type 'Record<string, unknown>' to type 'NextStatesResponse' may be a mistake
```

### What changed
- Added `unknown` intermediate cast in `parseNextStatesResponse`

### Why
Production build was failing on main after merging PR #34.

@HSILA please review.