### PR TITLE
chore(extraction): reduce worker and library polling

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,4 +31,5 @@ REDIS_URL=redis://localhost:6379
 
 # Extraction Agent
 OPENROUTER_API_KEY=
+EXTRACTION_WORKER_POLL_DELAY_SECONDS=15
 EXTRACTION_AGENT_MODEL="qwen/qwen3-vl-235b-a22b-instruct"

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -57,6 +57,7 @@ class Settings(BaseSettings):
     # Extraction Agent
     openrouter_api_key: str
     extraction_agent_model: str = "qwen/qwen-3-vl-235b-a22b-instruct"
+    extraction_worker_poll_delay_seconds: float = 15.0
 
 
 # Rate limiting

--- a/backend/app/workers/extraction_worker.py
+++ b/backend/app/workers/extraction_worker.py
@@ -688,4 +688,4 @@ class WorkerSettings:
     job_timeout = 1200
     keep_result = 0
     health_check_interval = 600
-    poll_delay = 5
+    poll_delay = get_settings().extraction_worker_poll_delay_seconds

--- a/frontend/src/app/(dashboard)/library/page.tsx
+++ b/frontend/src/app/(dashboard)/library/page.tsx
@@ -37,6 +37,7 @@ export default function LibraryPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isUploadOpen, setIsUploadOpen] = useState(false);
+  const [isTabVisible, setIsTabVisible] = useState(true);
   const [extractionProgress, setExtractionProgress] = useState<
     Record<number, number>
   >({});
@@ -89,8 +90,23 @@ export default function LibraryPage() {
     }
   }, [activeTab, fetchMyResources, fetchPublicResources]);
 
+  useEffect(() => {
+    const updateVisibility = () => {
+      setIsTabVisible(document.visibilityState === "visible");
+    };
+
+    updateVisibility();
+    document.addEventListener("visibilitychange", updateVisibility);
+
+    return () => {
+      document.removeEventListener("visibilitychange", updateVisibility);
+    };
+  }, []);
+
   // Poll for extraction progress
   useEffect(() => {
+    if (activeTab !== "my" || !isTabVisible) return;
+
     const processingResources = myResources.filter(
       (r) =>
         r.extraction_status === "pending" || r.extraction_status === "processing"
@@ -117,10 +133,10 @@ export default function LibraryPage() {
           // Ignore errors
         }
       }
-    }, 2000);
+    }, 5000);
 
     return () => clearInterval(interval);
-  }, [myResources, fetchMyResources]);
+  }, [activeTab, isTabVisible, myResources, fetchMyResources]);
 
   const handleExtract = async (id: number) => {
     try {


### PR DESCRIPTION
## Summary

- make extraction worker poll delay configurable via environment
- set the worker poll delay default to 15 seconds
- slow library progress polling from 2s to 5s
- pause library progress polling when the tab is hidden

## Problem

The extraction flow was doing avoidable Redis-backed polling from two places:

- the ARQ worker polled the queue on a hardcoded interval
- the library page polled extraction progress every 2 seconds per active resource

## Testing

- `cd frontend && npm run lint`
- `cd backend && . .venv/bin/activate && python -m compileall app/core/__init__.py app/workers/extraction_worker.py`

Closes #49