### PR TITLE
feature: make R2 storage operations non-blocking in async paths

### DIFF
--- a/backend/app/api/v1/resources.py
+++ b/backend/app/api/v1/resources.py
@@ -207,7 +207,10 @@ async def confirm_upload(
 
     # Ensure authoritative page_count and thumbnail from the uploaded PDF.
     needs_page_count = not resource.page_count
-    needs_thumbnail = not storage.file_exists(resource.content_hash, folder="thumbnails")
+    needs_thumbnail = not await storage.async_file_exists(
+        resource.content_hash,
+        folder="thumbnails",
+    )
 
     if needs_page_count or needs_thumbnail:
         try:
@@ -217,7 +220,10 @@ async def confirm_upload(
             from PIL import Image
 
             # Download PDF from R2
-            pdf_bytes = storage.download_file(resource.content_hash, folder="raw")
+            pdf_bytes = await storage.async_download_file(
+                resource.content_hash,
+                folder="raw",
+            )
 
             # Open PDF with PyMuPDF
             doc = fitz.open(stream=pdf_bytes, filetype="pdf")
@@ -234,7 +240,10 @@ async def confirm_upload(
 
                 thumbnail_buffer = io.BytesIO()
                 img.save(thumbnail_buffer, format="WEBP", quality=85)
-                storage.upload_thumbnail(thumbnail_buffer.getvalue(), resource.content_hash)
+                await storage.async_upload_thumbnail(
+                    thumbnail_buffer.getvalue(),
+                    resource.content_hash,
+                )
 
             doc.close()
         except Exception as e:
@@ -551,9 +560,9 @@ async def delete_resource(
             # Delete from R2
             content_hash = resource.content_hash
             if not content_hash.startswith("pending_"):
-                storage.delete_file(content_hash, folder="raw")
-                storage.delete_file(content_hash, folder="thumbnails")
-                storage.delete_processed_folder(content_hash)
+                await storage.async_delete_file(content_hash, folder="raw")
+                await storage.async_delete_file(content_hash, folder="thumbnails")
+                await storage.async_delete_processed_folder(content_hash)
 
             # Delete from database
             await session.delete(resource)
@@ -628,7 +637,7 @@ async def get_thumbnail_url(
         raise HTTPException(status_code=403, detail="Resource not accessible")
 
     # Generate URL
-    if not storage.file_exists(resource.content_hash, folder="thumbnails"):
+    if not await storage.async_file_exists(resource.content_hash, folder="thumbnails"):
         # Return default placeholder or 404?
         # For now, 404 so frontend can show default icon
         raise HTTPException(status_code=404, detail="Thumbnail not found")

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -8,6 +8,7 @@ Provides S3-compatible operations for:
 - Content hash computation
 """
 
+import asyncio
 import hashlib
 from typing import BinaryIO
 
@@ -276,6 +277,72 @@ class StorageService:
             MaxKeys=1,
         )
         return response.get("KeyCount", 0) > 0
+
+    # Async wrappers for network-bound boto3 operations.
+    # These keep async API/worker paths from blocking the event loop.
+    async def async_upload_file(
+        self,
+        file: bytes | BinaryIO,
+        key_or_hash: str,
+        folder: str | None = "raw",
+        content_type: str = "application/pdf",
+    ) -> None:
+        await asyncio.to_thread(
+            self.upload_file,
+            file,
+            key_or_hash,
+            folder,
+            content_type,
+        )
+
+    async def async_download_file(
+        self,
+        key_or_hash: str,
+        folder: str | None = "raw",
+    ) -> bytes:
+        return await asyncio.to_thread(self.download_file, key_or_hash, folder)
+
+    async def async_delete_file(
+        self,
+        key_or_hash: str,
+        folder: str | None = "raw",
+    ) -> None:
+        await asyncio.to_thread(self.delete_file, key_or_hash, folder)
+
+    async def async_delete_folder(self, prefix: str) -> None:
+        await asyncio.to_thread(self.delete_folder, prefix)
+
+    async def async_delete_processed_folder(self, content_hash: str) -> None:
+        await asyncio.to_thread(self.delete_processed_folder, content_hash)
+
+    async def async_delete_temp_folder(self, content_hash: str) -> None:
+        await asyncio.to_thread(self.delete_temp_folder, content_hash)
+
+    async def async_file_exists(
+        self,
+        key_or_hash: str,
+        folder: str | None = "raw",
+    ) -> bool:
+        return await asyncio.to_thread(self.file_exists, key_or_hash, folder)
+
+    async def async_folder_exists(self, prefix: str) -> bool:
+        return await asyncio.to_thread(self.folder_exists, prefix)
+
+    async def async_upload_thumbnail(self, image_bytes: bytes, content_hash: str) -> None:
+        await asyncio.to_thread(self.upload_thumbnail, image_bytes, content_hash)
+
+    async def async_upload_processed_page(
+        self,
+        markdown_content: str,
+        content_hash: str,
+        page_number: int,
+    ) -> None:
+        await asyncio.to_thread(
+            self.upload_processed_page,
+            markdown_content,
+            content_hash,
+            page_number,
+        )
 
     @staticmethod
     def compute_hash(file: BinaryIO, chunk_size: int = 8192) -> str:

--- a/backend/app/workers/extraction_worker.py
+++ b/backend/app/workers/extraction_worker.py
@@ -30,7 +30,7 @@ from app.models.resource import ExtractionStatus
 from app.services import RedisService, StorageService
 
 
-def _render_page_to_temp(
+async def _render_page_to_temp(
     storage: StorageService,
     resource: Resource,
     page_number: int,
@@ -38,7 +38,7 @@ def _render_page_to_temp(
     dpi: int = 200,
 ) -> None:
     """Render a single PDF page to temp storage (1-indexed page number)."""
-    pdf_bytes = storage.download_file(resource.content_hash, folder="raw")
+    pdf_bytes = await storage.async_download_file(resource.content_hash, folder="raw")
     doc = fitz.open(stream=pdf_bytes, filetype="pdf")
     try:
         total_pages = len(doc)
@@ -49,7 +49,7 @@ def _render_page_to_temp(
 
         page = doc[page_number - 1]
         pix = page.get_pixmap(dpi=dpi)
-        storage.upload_file(
+        await storage.async_upload_file(
             pix.tobytes("png"),
             f"temp/{resource.content_hash}/page_{page_number}.png",
             folder=None,
@@ -59,9 +59,13 @@ def _render_page_to_temp(
         doc.close()
 
 
-def _ensure_thumbnail(storage: StorageService, resource: Resource, doc: fitz.Document) -> None:
+async def _ensure_thumbnail(
+    storage: StorageService,
+    resource: Resource,
+    doc: fitz.Document,
+) -> None:
     """Create thumbnail if missing."""
-    if storage.file_exists(resource.content_hash, folder="thumbnails"):
+    if await storage.async_file_exists(resource.content_hash, folder="thumbnails"):
         return
 
     if len(doc) == 0:
@@ -74,13 +78,13 @@ def _ensure_thumbnail(storage: StorageService, resource: Resource, doc: fitz.Doc
 
     thumbnail_buffer = io.BytesIO()
     img.save(thumbnail_buffer, format="WEBP", quality=85)
-    storage.upload_thumbnail(thumbnail_buffer.getvalue(), resource.content_hash)
+    await storage.async_upload_thumbnail(thumbnail_buffer.getvalue(), resource.content_hash)
 
 
-def _safe_cleanup_temp_folder(storage: StorageService, content_hash: str) -> None:
+async def _safe_cleanup_temp_folder(storage: StorageService, content_hash: str) -> None:
     """Delete temp folder best-effort."""
     try:
-        storage.delete_temp_folder(content_hash)
+        await storage.async_delete_temp_folder(content_hash)
     except Exception as e:
         logger.warning(f"Failed to clean temp folder for {content_hash}: {e}")
 
@@ -119,7 +123,10 @@ async def prepare_extraction(ctx: dict, resource_id: int) -> dict:
 
             if total_pages <= 0:
                 try:
-                    pdf_bytes = storage.download_file(resource.content_hash, folder="raw")
+                    pdf_bytes = await storage.async_download_file(
+                        resource.content_hash,
+                        folder="raw",
+                    )
                 except Exception as e:
                     logger.error(f"Failed to download PDF for page_count: {e}")
                     resource.extraction_status = ExtractionStatus.FAILED
@@ -157,13 +164,16 @@ async def prepare_extraction(ctx: dict, resource_id: int) -> dict:
             await session.flush()
 
             # Ensure thumbnail exists
-            if not storage.file_exists(resource.content_hash, folder="thumbnails"):
+            if not await storage.async_file_exists(resource.content_hash, folder="thumbnails"):
                 if doc is None:
                     if pdf_bytes is None:
-                        pdf_bytes = storage.download_file(resource.content_hash, folder="raw")
+                        pdf_bytes = await storage.async_download_file(
+                            resource.content_hash,
+                            folder="raw",
+                        )
                     doc = fitz.open(stream=pdf_bytes, filetype="pdf")
                 try:
-                    _ensure_thumbnail(storage, resource, doc)
+                    await _ensure_thumbnail(storage, resource, doc)
                 except Exception as e:
                     logger.warning(f"Failed to generate thumbnail for resource {resource_id}: {e}")
 
@@ -171,13 +181,16 @@ async def prepare_extraction(ctx: dict, resource_id: int) -> dict:
             missing_pages: list[int] = []
             for page_num in range(1, total_pages + 1):
                 page_key = f"temp/{resource.content_hash}/page_{page_num}.png"
-                if not storage.file_exists(page_key, folder=None):
+                if not await storage.async_file_exists(page_key, folder=None):
                     missing_pages.append(page_num)
 
             if missing_pages:
                 if doc is None:
                     if pdf_bytes is None:
-                        pdf_bytes = storage.download_file(resource.content_hash, folder="raw")
+                        pdf_bytes = await storage.async_download_file(
+                            resource.content_hash,
+                            folder="raw",
+                        )
                     doc = fitz.open(stream=pdf_bytes, filetype="pdf")
 
                 logger.info(
@@ -186,7 +199,7 @@ async def prepare_extraction(ctx: dict, resource_id: int) -> dict:
                 for page_num in missing_pages:
                     page = doc[page_num - 1]
                     pix = page.get_pixmap(dpi=200)
-                    storage.upload_file(
+                    await storage.async_upload_file(
                         pix.tobytes("png"),
                         f"temp/{resource.content_hash}/page_{page_num}.png",
                         folder=None,
@@ -218,7 +231,7 @@ async def prepare_extraction(ctx: dict, resource_id: int) -> dict:
             if not incomplete_pages:
                 resource.extraction_status = ExtractionStatus.COMPLETED
                 resource.processed_at = utc_now()
-                _safe_cleanup_temp_folder(storage, resource.content_hash)
+                await _safe_cleanup_temp_folder(storage, resource.content_hash)
 
             await session.commit()
 
@@ -300,19 +313,22 @@ async def extract_page(ctx: dict, resource_id: int, page_number: int) -> dict:
             png_bytes: bytes | None = None
 
             try:
-                png_bytes = storage.download_file(temp_path, folder=None)
+                png_bytes = await storage.async_download_file(temp_path, folder=None)
             except Exception:
                 # Self-healing fallback: render missing page image on demand.
                 try:
-                    _render_page_to_temp(storage, resource, page_number)
-                    png_bytes = storage.download_file(temp_path, folder=None)
+                    await _render_page_to_temp(storage, resource, page_number)
+                    png_bytes = await storage.async_download_file(temp_path, folder=None)
                 except Exception as render_error:
                     # If markdown already exists, mark complete and recover.
                     try:
                         processed_path = (
                             f"processed/{resource.content_hash}/page_{page_number:04d}.md"
                         )
-                        existing_markdown = storage.download_file(processed_path, folder=None)
+                        existing_markdown = await storage.async_download_file(
+                            processed_path,
+                            folder=None,
+                        )
                         if existing_markdown:
                             page.status = PageStatus.COMPLETED
                             page.completed_at = utc_now()
@@ -325,7 +341,10 @@ async def extract_page(ctx: dict, resource_id: int, page_number: int) -> dict:
                             )
                             await session.commit()
                             if completed_now:
-                                _safe_cleanup_temp_folder(storage, resource.content_hash)
+                                await _safe_cleanup_temp_folder(
+                                    storage,
+                                    resource.content_hash,
+                                )
                             return {
                                 "success": True,
                                 "page": page_number,
@@ -346,7 +365,7 @@ async def extract_page(ctx: dict, resource_id: int, page_number: int) -> dict:
             result = agent.extract_page(png_bytes, page_number)
 
             if result.success:
-                storage.upload_processed_page(
+                await storage.async_upload_processed_page(
                     result.markdown,
                     resource.content_hash,
                     page_number,
@@ -370,12 +389,12 @@ async def extract_page(ctx: dict, resource_id: int, page_number: int) -> dict:
 
             if result.success:
                 try:
-                    storage.delete_file(temp_path, folder=None)
+                    await storage.async_delete_file(temp_path, folder=None)
                 except Exception as e:
                     logger.warning(f"Failed to delete temp file {temp_path}: {e}")
 
                 if completed_now:
-                    _safe_cleanup_temp_folder(storage, resource.content_hash)
+                    await _safe_cleanup_temp_folder(storage, resource.content_hash)
 
             return {"success": result.success, "page": page_number}
 
@@ -551,7 +570,7 @@ async def check_orphan_resources(ctx: dict):
                     resource.extraction_status = ExtractionStatus.COMPLETED
                     resource.processed_at = utc_now()
                     fixed += 1
-                    _safe_cleanup_temp_folder(storage, resource.content_hash)
+                    await _safe_cleanup_temp_folder(storage, resource.content_hash)
                     logger.info(
                         f"Fixed orphan resource {resource.id}: all {total} pages completed"
                     )

--- a/backend/tests/test_resources_download.py
+++ b/backend/tests/test_resources_download.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from app.api.v1.resources import get_download_url
+from app.api.v1.resources import get_download_url, get_thumbnail_url
 from app.models import Resource, User, UserResource
 
 
@@ -61,4 +61,56 @@ async def test_get_download_url_returns_hash_filename_and_hash_based_url() -> No
         content_hash,
         folder="raw",
         expires_in=3600,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_thumbnail_url_uses_async_existence_check() -> None:
+    content_hash = "b" * 64
+
+    resource = Resource(
+        id=1,
+        content_hash=content_hash,
+        size_bytes=123,
+        page_count=1,
+        file_name="original-name.pdf",
+        is_public=False,
+        uploaded_by=1,
+    )
+    current_user = User(
+        id=1,
+        email="user@example.com",
+        password_hash="hashed",
+    )
+    user_resource = UserResource(
+        user_id=1,
+        resource_id=1,
+        name="custom title",
+    )
+
+    session = AsyncMock()
+    session.get.return_value = resource
+    session.execute.return_value = _ScalarResult(user_resource)
+
+    storage = Mock()
+    storage.async_file_exists = AsyncMock(return_value=True)
+    storage.generate_download_url.return_value = "https://example.com/thumb"
+
+    result = await get_thumbnail_url(
+        resource_id=1,
+        session=session,
+        current_user=current_user,
+        storage=storage,
+    )
+
+    assert result == {"url": "https://example.com/thumb"}
+    storage.async_file_exists.assert_awaited_once_with(
+        content_hash,
+        folder="thumbnails",
+    )
+    storage.generate_download_url.assert_called_once_with(
+        content_hash,
+        folder="thumbnails",
+        expires_in=3600,
+        response_content_type="image/webp",
     )

--- a/backend/tests/test_storage_service_async.py
+++ b/backend/tests/test_storage_service_async.py
@@ -1,0 +1,64 @@
+import pytest
+
+from app.services.storage_service import StorageService
+
+
+@pytest.mark.asyncio
+async def test_async_download_file_uses_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = StorageService.__new__(StorageService)
+
+    called = {}
+
+    async def fake_to_thread(func, *args):
+        called["func"] = func
+        called["args"] = args
+        return b"pdf-bytes"
+
+    monkeypatch.setattr("app.services.storage_service.asyncio.to_thread", fake_to_thread)
+
+    result = await service.async_download_file("abc123", folder="raw")
+
+    assert result == b"pdf-bytes"
+    assert called["func"] == service.download_file
+    assert called["args"] == ("abc123", "raw")
+
+
+@pytest.mark.asyncio
+async def test_async_file_exists_uses_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = StorageService.__new__(StorageService)
+
+    called = {}
+
+    async def fake_to_thread(func, *args):
+        called["func"] = func
+        called["args"] = args
+        return True
+
+    monkeypatch.setattr("app.services.storage_service.asyncio.to_thread", fake_to_thread)
+
+    exists = await service.async_file_exists("abc123", folder="thumbnails")
+
+    assert exists is True
+    assert called["func"] == service.file_exists
+    assert called["args"] == ("abc123", "thumbnails")
+
+
+@pytest.mark.asyncio
+async def test_async_delete_processed_folder_uses_to_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = StorageService.__new__(StorageService)
+
+    called = {}
+
+    async def fake_to_thread(func, *args):
+        called["func"] = func
+        called["args"] = args
+        return None
+
+    monkeypatch.setattr("app.services.storage_service.asyncio.to_thread", fake_to_thread)
+
+    await service.async_delete_processed_folder("hash-123")
+
+    assert called["func"] == service.delete_processed_folder
+    assert called["args"] == ("hash-123",)


### PR DESCRIPTION
Closes #59

## Root cause
Async API handlers and extraction worker jobs called synchronous boto3 network methods directly. Those calls block the event loop while waiting on R2 I/O.

## Changes
- Added async storage wrappers in `StorageService` using `asyncio.to_thread(...)` for network-bound upload/download/delete/existence operations.
- Updated async resource API flows in `backend/app/api/v1/resources.py` to await async storage operations:
  - upload confirm metadata/thumbnail finalization
  - owner delete cleanup (raw, thumbnail, processed)
  - thumbnail existence checks
- Updated extraction worker async paths in `backend/app/workers/extraction_worker.py` to await async storage operations:
  - page count/thumbnail prep downloads
  - temp page existence checks and uploads
  - page extraction temp download/rebuild, processed upload, and cleanup
  - orphan/completion temp-folder cleanup
- Added tests for async wrapper delegation and an affected async API flow:
  - `backend/tests/test_storage_service_async.py`
  - `backend/tests/test_resources_download.py` (thumbnail path)

## Risk
- `asyncio.to_thread` adds threadpool scheduling overhead for storage calls.
- Behavior should remain functionally equivalent, but higher parallel job counts may increase threadpool pressure.

## Verification
- `uv run pytest -q`
  - Result: `10 passed`
- `uv run pytest -q tests/test_storage_service.py tests/test_storage_service_async.py tests/test_resources_download.py`
  - Result: `7 passed`
