### PR TITLE
test(frontend): balanced critical-path coverage

### DIFF
--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -1,0 +1,74 @@
+# Frontend test strategy
+
+The frontend test suite is run with Bun's built-in test runner
+(`bun test`). It is intentionally focused on **logic and contracts** —
+not on rendered output — so it stays fast, stable, and meaningful as the
+UI keeps changing.
+
+## How to run
+
+```bash
+bun test                  # from frontend/
+bun test src/lib          # narrow to a directory
+bun test src/proxy.test   # narrow to a single file
+```
+
+The `test` script in `package.json` (`bun test`) is provided so editor /
+CI integrations can run it the same way as the rest of the npm scripts.
+
+## What is covered, and why
+
+The product surface is small enough that a few well-chosen tests can lock
+down the load-bearing behavior. The current suite is organised by what
+would actually break a user if it regressed:
+
+| Area | File | Why it matters |
+| --- | --- | --- |
+| Middleware redirect / open-redirect safety | `src/proxy.test.ts` | `next=` is user-controlled; a regression would be an auth-page open redirect. |
+| Authenticated fetch + 401 refresh + login redirect | `src/lib/api/fetch-with-auth.test.ts` | Every API call goes through this. Bugs cause silent logouts, double refreshes, or losing the post-login destination. |
+| FastAPI error parsing | `src/lib/api-error.test.ts` | Every toast/alert flows through `parseApiError`. A regression silently degrades every error UI. |
+| Decks / Cards / Resources API clients | `src/lib/api/{decks,cards,resources}.test.ts` | Request shape + runtime validators + error pass-through. A backend response-shape change should fail loudly here, not in the UI. |
+| Active-nav highlighting | `src/lib/nav.test.ts` | The `isActiveNavLink` helper is shared by the sidebar and bottom nav, and a naive `startsWith` would highlight `/decks` for `/decks-archive`. |
+
+## What is deliberately not tested
+
+- **Rendered React components.** No jsdom / Testing Library is set up.
+  Rendering modals and pages here would mean mocking Next router, theme,
+  auth, `sonner`, Radix portals, and intersection observers — a lot of
+  brittle machinery for tests that mostly re-assert layout. Where a
+  component has interesting logic (filters, sort modes, validators), we
+  prefer to extract the pure part and test it directly.
+- **Visual / snapshot tests.** They lock in style decisions and rot
+  quickly under the active UI redesign work, so we skip them entirely.
+- **Backend integration.** Tests stub `globalThis.fetch`; we are not
+  verifying the FastAPI server.
+
+If a future change makes rendered component tests genuinely worth their
+weight (e.g. an interaction that can't be expressed as a pure helper),
+the right move is to add `happy-dom` + `@testing-library/react` and pin
+that scope tightly — not to retrofit the whole UI.
+
+## Patterns used by the suite
+
+- **Stub `globalThis.fetch` via `installFetchMock`** in
+  `src/lib/test-utils.ts`. Each test enqueues handlers FIFO; an
+  unexpected extra `fetch` call throws, so missed requests are loud.
+- **Stub `window.location` via `installWindowMock`** when the code under
+  test reads `window.location.pathname/search/hash` or calls
+  `window.location.replace`. The mock records every `replace()` call so
+  redirect behavior is assertable.
+- **Reset shared module state** between tests where needed —
+  `fetch-with-auth` exports `__resetForTests()` so the in-flight refresh
+  promise can't leak across tests.
+
+## Adding new tests
+
+Co-locate `*.test.ts` next to the module it tests. Prefer:
+
+1. Pure helpers (extract one if you have to) — fastest, hardest to break.
+2. API client request / response contracts using `installFetchMock`.
+3. Middleware / routing behavior using `mock.module()` for `next/server`.
+
+Avoid wide integration tests in this layer; the value-to-maintenance
+ratio is poor relative to a handful of well-aimed Playwright tests
+(future work).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "bun --bun next dev --turbopack",
     "build": "bun --bun next build",
     "start": "bun --bun next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "bun test"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",

--- a/frontend/src/components/layout/bottom-nav.tsx
+++ b/frontend/src/components/layout/bottom-nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Icon, type IconName } from "@/components/glot/icon";
+import { isActiveNavLink } from "@/lib/nav";
 
 interface NavItem {
   href: string;
@@ -17,11 +18,6 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/refinery", label: "Refinery", icon: "sparkle", chip: "AI" },
   { href: "/library", label: "Library", icon: "library" },
 ];
-
-function isActive(pathname: string, href: string) {
-  if (href === "/") return pathname === "/";
-  return pathname === href || pathname.startsWith(`${href}/`);
-}
 
 export function BottomNav() {
   const pathname = usePathname();
@@ -45,7 +41,7 @@ export function BottomNav() {
       }}
     >
       {NAV_ITEMS.map((item) => {
-        const active = isActive(pathname, item.href);
+        const active = isActiveNavLink(pathname, item.href);
         return (
           <Link
             key={item.href}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { Wordmark } from "@/components/glot/wordmark";
 import { Icon, type IconName } from "@/components/glot/icon";
 import { useAuth } from "@/components/providers/auth-provider";
+import { isActiveNavLink } from "@/lib/nav";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -21,11 +22,6 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/refinery", label: "Refinery", icon: "sparkle", chip: "AI" },
   { href: "/library", label: "Library", icon: "library" },
 ];
-
-function isActive(pathname: string, href: string) {
-  if (href === "/") return pathname === "/";
-  return pathname === href || pathname.startsWith(`${href}/`);
-}
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -92,7 +88,7 @@ export function Sidebar() {
         }}
       >
         {NAV_ITEMS.map((item) => {
-          const active = isActive(pathname, item.href);
+          const active = isActiveNavLink(pathname, item.href);
           return (
             <Link
               key={item.href}

--- a/frontend/src/lib/api-error.test.ts
+++ b/frontend/src/lib/api-error.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for `parseApiError`, which converts FastAPI error response bodies
+ * into user-facing strings. The toast/alert messages everywhere in the
+ * app flow through this function, so a regression here silently degrades
+ * every error UI in the product.
+ *
+ * Run with: `bun test src/lib/api-error.test.ts`
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseApiError } from "./api-error";
+
+describe("parseApiError", () => {
+  test("string detail is returned verbatim", () => {
+    expect(parseApiError({ detail: "Invalid credentials" })).toBe(
+      "Invalid credentials",
+    );
+  });
+
+  test("pydantic validation array is joined with periods", () => {
+    const body = {
+      detail: [
+        { msg: "field required", loc: ["body", "email"] },
+        { msg: "value is not a valid email", loc: ["body", "email"] },
+      ],
+    };
+    expect(parseApiError(body)).toBe(
+      "field required. value is not a valid email",
+    );
+  });
+
+  test("strips the `Value error, ` prefix that Pydantic adds", () => {
+    const body = {
+      detail: [
+        { msg: "Value error, must be at least 8 characters", loc: ["body", "password"] },
+        { msg: "value error, lowercase prefix too", loc: ["body", "password"] },
+      ],
+    };
+    // Both casing variants of the prefix should be stripped.
+    expect(parseApiError(body)).toBe(
+      "must be at least 8 characters. lowercase prefix too",
+    );
+  });
+
+  test("validation entries without a `msg` field are skipped", () => {
+    const body = {
+      detail: [
+        { loc: ["body", "email"] },
+        { msg: "required" },
+      ],
+    };
+    expect(parseApiError(body)).toBe("required");
+  });
+
+  test("empty validation array falls back to a generic message", () => {
+    expect(parseApiError({ detail: [] })).toBe("Validation failed");
+  });
+
+  test("validation array with only entries missing msg falls back too", () => {
+    expect(parseApiError({ detail: [{ loc: ["body"] }] })).toBe(
+      "Validation failed",
+    );
+  });
+
+  test("missing detail field falls back to a generic message", () => {
+    expect(parseApiError({})).toBe("An error occurred");
+    expect(parseApiError({ message: "oops" })).toBe("An error occurred");
+  });
+
+  test("non-object / nullish input is handled defensively", () => {
+    expect(parseApiError(null)).toBe("An error occurred");
+    expect(parseApiError(undefined)).toBe("An error occurred");
+    expect(parseApiError("oops")).toBe("An error occurred");
+    expect(parseApiError(42)).toBe("An error occurred");
+  });
+
+  test("non-string, non-array detail falls back", () => {
+    // A backend bug could send a number or object — make sure we still
+    // return a string instead of crashing the toast call site.
+    expect(parseApiError({ detail: 500 })).toBe("An error occurred");
+    expect(parseApiError({ detail: { nested: true } })).toBe("An error occurred");
+  });
+});

--- a/frontend/src/lib/api/cards.test.ts
+++ b/frontend/src/lib/api/cards.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for the `cardsApi` client.
+ *
+ * Covers listing with filters, the due-cards endpoint, runtime parsing
+ * of nested review/scheduling shapes, and the `deck_id === null` guard
+ * on update.
+ *
+ * Run with: `bun test src/lib/api/cards.test.ts`
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { __resetForTests } from "./fetch-with-auth";
+import {
+  cardsApi,
+  type Card,
+  type NextStatesResponse,
+  type ReviewResponse,
+} from "./cards";
+import {
+  installFetchMock,
+  installWindowMock,
+  jsonResponse,
+  restoreFetch,
+  restoreWindow,
+  type FetchMock,
+} from "@/lib/test-utils";
+
+function makeCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: 1,
+    sequence: 1,
+    front_content: "front",
+    back_content: "back",
+    meta_data: {},
+    tags: [],
+    deck_id: 1,
+    difficulty: 0,
+    stability: 0,
+    state: "new",
+    reps: 0,
+    lapses: 0,
+    last_review_at: null,
+    next_review_at: null,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeNextStates(): NextStatesResponse {
+  const info = { interval_days: 1, new_difficulty: 0.3, new_stability: 1.5 };
+  return { again: info, hard: info, good: info, easy: info };
+}
+
+let fetchMock: FetchMock;
+
+beforeEach(() => {
+  __resetForTests();
+  installWindowMock();
+  fetchMock = installFetchMock();
+});
+
+afterEach(() => {
+  restoreFetch();
+  restoreWindow();
+});
+
+describe("cardsApi.listCards", () => {
+  test("emits only limit/offset when no filters are given", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ items: [], total: 0, limit: 100, offset: 0 }),
+    );
+
+    await cardsApi.listCards();
+
+    expect(fetchMock.calls[0].url).toBe(
+      "/api/v1/cards?limit=100&offset=0",
+    );
+  });
+
+  test("encodes deck_id, state, and tag filters", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ items: [makeCard()], total: 1, limit: 20, offset: 0 }),
+    );
+
+    const response = await cardsApi.listCards({
+      deck_id: 7,
+      state: "review",
+      tag: "kanji",
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(response.items).toHaveLength(1);
+    const url = new URL(fetchMock.calls[0].url, "http://localhost");
+    expect(url.pathname).toBe("/api/v1/cards");
+    expect(url.searchParams.get("deck_id")).toBe("7");
+    expect(url.searchParams.get("state")).toBe("review");
+    expect(url.searchParams.get("tag")).toBe("kanji");
+    expect(url.searchParams.get("limit")).toBe("20");
+    expect(url.searchParams.get("offset")).toBe("0");
+  });
+
+  test("rejects responses with an invalid card state", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({
+        items: [{ ...makeCard(), state: "graduated" }],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      }),
+    );
+
+    await expect(cardsApi.listCards()).rejects.toThrow(/invalid state/i);
+  });
+
+  test("rejects when items is missing or wrong type", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ items: "not-an-array", total: 0, limit: 0, offset: 0 }),
+    );
+
+    await expect(cardsApi.listCards()).rejects.toThrow(/expected array/i);
+  });
+
+  test("surfaces a parsed detail message on error", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ detail: "deck not found" }, { status: 404 }),
+    );
+
+    await expect(cardsApi.listCards({ deck_id: 999 })).rejects.toThrow(
+      "deck not found",
+    );
+  });
+});
+
+describe("cardsApi.getDueCards", () => {
+  test("defaults limit to 20 and omits deck_id when not given", async () => {
+    fetchMock.enqueue(() => jsonResponse([]));
+
+    await cardsApi.getDueCards();
+
+    expect(fetchMock.calls[0].url).toBe("/api/v1/cards/due?limit=20");
+  });
+
+  test("includes deck_id when provided", async () => {
+    fetchMock.enqueue(() => jsonResponse([makeCard({ id: 42 })]));
+
+    const cards = await cardsApi.getDueCards({ deck_id: 3, limit: 5 });
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].id).toBe(42);
+    expect(fetchMock.calls[0].url).toBe(
+      "/api/v1/cards/due?deck_id=3&limit=5",
+    );
+  });
+});
+
+describe("cardsApi.updateCard", () => {
+  test("rejects deck_id === null before issuing a request", async () => {
+    await expect(
+      // Cast: the public type forbids null, but we explicitly guard so
+      // a callsite that defeats the type checker still fails loudly.
+      cardsApi.updateCard(1, { deck_id: null } as unknown as { deck_id?: number }),
+    ).rejects.toThrow(/deck_id cannot be null/i);
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  test("PUTs the provided payload otherwise", async () => {
+    fetchMock.enqueue(() => jsonResponse(makeCard({ id: 1, deck_id: 9 })));
+
+    const card = await cardsApi.updateCard(1, { deck_id: 9 });
+
+    expect(card.deck_id).toBe(9);
+    const call = fetchMock.calls[0];
+    expect(call.url).toBe("/api/v1/cards/1");
+    expect(call.init?.method).toBe("PUT");
+    expect(JSON.parse(call.init?.body as string)).toEqual({ deck_id: 9 });
+  });
+});
+
+describe("cardsApi.reviewCard / previewCard", () => {
+  test("review parses card + next_states + message", async () => {
+    const next = makeNextStates();
+    const responseBody: ReviewResponse = {
+      card: makeCard({ id: 5, state: "review" }),
+      next_states: next,
+      message: "ok",
+    };
+    fetchMock.enqueue(() => jsonResponse(responseBody));
+
+    const result = await cardsApi.reviewCard(5, { rating: 3 });
+
+    expect(result.card.id).toBe(5);
+    expect(result.message).toBe("ok");
+    expect(result.next_states.good.interval_days).toBe(1);
+    const call = fetchMock.calls[0];
+    expect(call.url).toBe("/api/v1/cards/5/review");
+    expect(call.init?.method).toBe("POST");
+    expect(JSON.parse(call.init?.body as string)).toEqual({ rating: 3 });
+  });
+
+  test("preview returns parsed next_states", async () => {
+    fetchMock.enqueue(() => jsonResponse(makeNextStates()));
+
+    const result = await cardsApi.previewCard(8);
+
+    expect(result.again.interval_days).toBe(1);
+    expect(fetchMock.calls[0].url).toBe("/api/v1/cards/8/preview");
+  });
+
+  test("preview rejects when a scheduling bucket is malformed", async () => {
+    const bad = { ...makeNextStates(), easy: { interval_days: "soon" } };
+    fetchMock.enqueue(() => jsonResponse(bad));
+
+    await expect(cardsApi.previewCard(8)).rejects.toThrow(
+      /Next states\.easy: invalid interval_days/i,
+    );
+  });
+});
+
+describe("cardsApi.createCard / deleteCard", () => {
+  test("createCard posts with body and credentials", async () => {
+    fetchMock.enqueue(() => jsonResponse(makeCard({ id: 99 })));
+
+    const card = await cardsApi.createCard({
+      deck_id: 1,
+      front_content: "f",
+      back_content: "b",
+    });
+
+    expect(card.id).toBe(99);
+    const call = fetchMock.calls[0];
+    expect(call.url).toBe("/api/v1/cards");
+    expect(call.init?.method).toBe("POST");
+    expect(call.init?.credentials).toBe("include");
+    expect(JSON.parse(call.init?.body as string)).toEqual({
+      deck_id: 1,
+      front_content: "f",
+      back_content: "b",
+    });
+  });
+
+  test("deleteCard surfaces parsed detail on failure", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ detail: "card already gone" }, { status: 404 }),
+    );
+
+    await expect(cardsApi.deleteCard(1)).rejects.toThrow("card already gone");
+  });
+});

--- a/frontend/src/lib/api/decks.test.ts
+++ b/frontend/src/lib/api/decks.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the `decksApi` client.
+ *
+ * We stub `globalThis.fetch` (which `fetchWithAuth` ultimately calls) so
+ * each test asserts on the full request shape — URL, method, headers,
+ * body — as well as how responses are parsed and how backend errors
+ * are surfaced via `parseApiError`.
+ *
+ * Run with: `bun test src/lib/api/decks.test.ts`
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { __resetForTests } from "./fetch-with-auth";
+import { decksApi, type Deck } from "./decks";
+import {
+  installFetchMock,
+  installWindowMock,
+  jsonResponse,
+  restoreFetch,
+  restoreWindow,
+  type FetchMock,
+} from "@/lib/test-utils";
+
+function makeDeck(overrides: Partial<Deck> = {}): Deck {
+  return {
+    id: 1,
+    name: "Japanese N5",
+    description: null,
+    color: "#3b82f6",
+    tags: null,
+    cards_count: 0,
+    new_count: 0,
+    due_count: 0,
+    last_studied_at: null,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+let fetchMock: FetchMock;
+
+beforeEach(() => {
+  __resetForTests();
+  installWindowMock();
+  fetchMock = installFetchMock();
+});
+
+afterEach(() => {
+  restoreFetch();
+  restoreWindow();
+});
+
+describe("decksApi.listDecks", () => {
+  test("builds default limit/offset query", async () => {
+    fetchMock.enqueue(() => jsonResponse([makeDeck()]));
+
+    const decks = await decksApi.listDecks();
+
+    expect(decks).toHaveLength(1);
+    expect(fetchMock.calls).toHaveLength(1);
+    expect(fetchMock.calls[0].url).toBe(
+      "/api/v1/decks?limit=100&offset=0",
+    );
+    expect(fetchMock.calls[0].init?.credentials).toBe("include");
+  });
+
+  test("honours custom limit/offset", async () => {
+    fetchMock.enqueue(() => jsonResponse([]));
+
+    await decksApi.listDecks({ limit: 25, offset: 50 });
+
+    expect(fetchMock.calls[0].url).toBe(
+      "/api/v1/decks?limit=25&offset=50",
+    );
+  });
+
+  test("throws with parsed error message on non-OK response", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ detail: "Forbidden" }, { status: 403 }),
+    );
+
+    await expect(decksApi.listDecks()).rejects.toThrow("Forbidden");
+  });
+
+  test("uses fallback message when response body is not JSON", async () => {
+    fetchMock.enqueue(
+      () => new Response("upstream down", { status: 503 }),
+    );
+
+    await expect(decksApi.listDecks()).rejects.toThrow(
+      "Failed to fetch decks",
+    );
+  });
+
+  test("rejects with a clear error when an item is shaped wrong", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse([{ ...makeDeck(), cards_count: "lots" as unknown as number }]),
+    );
+
+    await expect(decksApi.listDecks()).rejects.toThrow(
+      /invalid cards_count/i,
+    );
+  });
+
+  test("rejects when the top-level payload is not an array", async () => {
+    fetchMock.enqueue(() => jsonResponse({ items: [] }));
+
+    await expect(decksApi.listDecks()).rejects.toThrow(/expected array/i);
+  });
+});
+
+describe("decksApi.getDeck", () => {
+  test("hits the deck-by-id URL and returns the parsed deck", async () => {
+    fetchMock.enqueue(() => jsonResponse(makeDeck({ id: 42, name: "Kanji" })));
+
+    const deck = await decksApi.getDeck(42);
+
+    expect(deck.id).toBe(42);
+    expect(deck.name).toBe("Kanji");
+    expect(fetchMock.calls[0].url).toBe("/api/v1/decks/42");
+  });
+
+  test("surfaces 404 with parsed detail", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ detail: "Deck not found" }, { status: 404 }),
+    );
+
+    await expect(decksApi.getDeck(99)).rejects.toThrow("Deck not found");
+  });
+});
+
+describe("decksApi.createDeck", () => {
+  test("POSTs JSON payload with credentials", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse(makeDeck({ id: 7, name: "French", tags: ["fr"] })),
+    );
+
+    const deck = await decksApi.createDeck({
+      name: "French",
+      description: null,
+      color: "#22c55e",
+      tags: ["fr"],
+    });
+
+    expect(deck.id).toBe(7);
+    const call = fetchMock.calls[0];
+    expect(call.url).toBe("/api/v1/decks");
+    expect(call.init?.method).toBe("POST");
+    expect(call.init?.credentials).toBe("include");
+    expect((call.init?.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+    expect(JSON.parse(call.init?.body as string)).toEqual({
+      name: "French",
+      description: null,
+      color: "#22c55e",
+      tags: ["fr"],
+    });
+  });
+
+  test("propagates pydantic-style validation errors", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse(
+        {
+          detail: [
+            { msg: "field required", loc: ["body", "name"] },
+          ],
+        },
+        { status: 422 },
+      ),
+    );
+
+    await expect(
+      decksApi.createDeck({ name: "", description: null, color: null, tags: null }),
+    ).rejects.toThrow("field required");
+  });
+});
+
+describe("decksApi.updateDeck", () => {
+  test("PUTs JSON payload to the deck URL", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse(makeDeck({ id: 3, name: "Renamed" })),
+    );
+
+    const deck = await decksApi.updateDeck(3, { name: "Renamed" });
+
+    expect(deck.name).toBe("Renamed");
+    const call = fetchMock.calls[0];
+    expect(call.url).toBe("/api/v1/decks/3");
+    expect(call.init?.method).toBe("PUT");
+    expect(JSON.parse(call.init?.body as string)).toEqual({ name: "Renamed" });
+  });
+});
+
+describe("decksApi.deleteDeck", () => {
+  test("issues DELETE and resolves to void on 204", async () => {
+    fetchMock.enqueue(() => new Response(null, { status: 204 }));
+
+    await expect(decksApi.deleteDeck(5)).resolves.toBeUndefined();
+    const call = fetchMock.calls[0];
+    expect(call.url).toBe("/api/v1/decks/5");
+    expect(call.init?.method).toBe("DELETE");
+  });
+
+  test("throws with parsed detail when the delete fails", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ detail: "Cannot delete" }, { status: 409 }),
+    );
+
+    await expect(decksApi.deleteDeck(5)).rejects.toThrow("Cannot delete");
+  });
+});

--- a/frontend/src/lib/api/resources.test.ts
+++ b/frontend/src/lib/api/resources.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for the `resourcesApi` client + `computeFileHash`.
+ *
+ * The resources flow has unusual edges: (a) the R2 upload is a direct
+ * fetch with no auth, distinct from the rest of the API surface, and
+ * (b) the upload-deduplication path skips the R2 step entirely when
+ * `upload_url` is empty. Both are easy to regress, so we cover them.
+ *
+ * Run with: `bun test src/lib/api/resources.test.ts`
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { __resetForTests } from "./fetch-with-auth";
+import { computeFileHash, resourcesApi, type Resource } from "./resources";
+import {
+  installFetchMock,
+  installWindowMock,
+  jsonResponse,
+  restoreFetch,
+  restoreWindow,
+  type FetchMock,
+} from "@/lib/test-utils";
+
+function makeResource(overrides: Partial<Resource> = {}): Resource {
+  return {
+    id: 1,
+    content_hash: "deadbeef",
+    name: "Doc.pdf",
+    size_bytes: 1024,
+    page_count: 4,
+    is_public: false,
+    extraction_status: "none",
+    uploaded_at: "2025-01-01T00:00:00Z",
+    processed_at: null,
+    is_owner: true,
+    ...overrides,
+  };
+}
+
+let fetchMock: FetchMock;
+
+beforeEach(() => {
+  __resetForTests();
+  installWindowMock();
+  fetchMock = installFetchMock();
+});
+
+afterEach(() => {
+  restoreFetch();
+  restoreWindow();
+});
+
+describe("computeFileHash", () => {
+  test("returns a hex SHA-256 of the file contents", async () => {
+    // SHA-256 of "hello" is well-known.
+    const expected =
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+    const file = new File(["hello"], "test.txt", { type: "text/plain" });
+
+    const hash = await computeFileHash(file);
+
+    expect(hash).toBe(expected);
+  });
+
+  test("identical content produces identical hashes", async () => {
+    const a = new File(["same"], "a.pdf");
+    const b = new File(["same"], "b.pdf");
+    expect(await computeFileHash(a)).toBe(await computeFileHash(b));
+  });
+
+  test("different content produces different hashes", async () => {
+    const a = new File(["a"], "a.pdf");
+    const b = new File(["b"], "b.pdf");
+    expect(await computeFileHash(a)).not.toBe(await computeFileHash(b));
+  });
+});
+
+describe("resourcesApi.getMyResources", () => {
+  test("uses default limit/offset", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ items: [makeResource()], total: 1, limit: 50, offset: 0 }),
+    );
+
+    const r = await resourcesApi.getMyResources();
+
+    expect(r.items).toHaveLength(1);
+    expect(fetchMock.calls[0].url).toBe(
+      "/api/v1/resources?limit=50&offset=0",
+    );
+  });
+
+  test("throws on non-OK", async () => {
+    fetchMock.enqueue(() => new Response(null, { status: 500 }));
+    await expect(resourcesApi.getMyResources()).rejects.toThrow(
+      "Failed to fetch resources",
+    );
+  });
+});
+
+describe("resourcesApi.getPublicResources", () => {
+  test("omits `search` when not given", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ items: [], total: 0, limit: 50, offset: 0 }),
+    );
+
+    await resourcesApi.getPublicResources();
+
+    const url = new URL(fetchMock.calls[0].url, "http://localhost");
+    expect(url.pathname).toBe("/api/v1/resources/public");
+    expect(url.searchParams.get("search")).toBeNull();
+  });
+
+  test("encodes search query when provided", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ items: [], total: 0, limit: 10, offset: 5 }),
+    );
+
+    await resourcesApi.getPublicResources("calc & physics", 10, 5);
+
+    const url = new URL(fetchMock.calls[0].url, "http://localhost");
+    expect(url.searchParams.get("search")).toBe("calc & physics");
+    expect(url.searchParams.get("limit")).toBe("10");
+    expect(url.searchParams.get("offset")).toBe("5");
+  });
+});
+
+describe("resourcesApi.requestUpload", () => {
+  test("sends JSON body and returns the upload response", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ upload_url: "https://r2.example/x", resource_id: 10, expires_in: 60 }),
+    );
+
+    const res = await resourcesApi.requestUpload({
+      name: "Doc",
+      file_name: "Doc.pdf",
+      size_bytes: 200,
+      content_hash: "abcd",
+      is_public: false,
+    });
+
+    expect(res.resource_id).toBe(10);
+    const call = fetchMock.calls[0];
+    expect(call.url).toBe("/api/v1/resources/upload");
+    expect(call.init?.method).toBe("POST");
+    expect(JSON.parse(call.init?.body as string)).toMatchObject({
+      name: "Doc",
+      file_name: "Doc.pdf",
+    });
+  });
+
+  test("uses backend `detail` on failure", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ detail: "PDF too large" }, { status: 413 }),
+    );
+
+    await expect(
+      resourcesApi.requestUpload({
+        name: "Doc",
+        file_name: "Doc.pdf",
+        size_bytes: 9999999999,
+        content_hash: "abcd",
+        is_public: false,
+      }),
+    ).rejects.toThrow("PDF too large");
+  });
+});
+
+describe("resourcesApi.uploadFileToR2", () => {
+  test("PUTs the file body as application/pdf", async () => {
+    fetchMock.enqueue(() => new Response(null, { status: 200 }));
+
+    const file = new File(["data"], "doc.pdf", { type: "application/pdf" });
+    await resourcesApi.uploadFileToR2("https://r2.example/x", file);
+
+    const call = fetchMock.calls[0];
+    expect(call.url).toBe("https://r2.example/x");
+    expect(call.init?.method).toBe("PUT");
+    expect((call.init?.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/pdf",
+    );
+  });
+
+  test("throws on R2 failure", async () => {
+    fetchMock.enqueue(() => new Response(null, { status: 500 }));
+
+    const file = new File(["data"], "doc.pdf", { type: "application/pdf" });
+    await expect(
+      resourcesApi.uploadFileToR2("https://r2.example/x", file),
+    ).rejects.toThrow("Failed to upload file to storage");
+  });
+});
+
+describe("resourcesApi.deleteResource", () => {
+  test("issues DELETE and returns void on success", async () => {
+    fetchMock.enqueue(() => new Response(null, { status: 204 }));
+
+    await expect(resourcesApi.deleteResource(7)).resolves.toBeUndefined();
+    expect(fetchMock.calls[0].url).toBe("/api/v1/resources/7");
+    expect(fetchMock.calls[0].init?.method).toBe("DELETE");
+  });
+
+  test("uses parsed detail on failure", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ detail: "Not yours" }, { status: 403 }),
+    );
+    await expect(resourcesApi.deleteResource(7)).rejects.toThrow("Not yours");
+  });
+});
+
+describe("resourcesApi.getDownloadUrl", () => {
+  test("returns the `url` field from the response", async () => {
+    fetchMock.enqueue(() => jsonResponse({ url: "https://r2.example/sig" }));
+
+    const url = await resourcesApi.getDownloadUrl(3);
+
+    expect(url).toBe("https://r2.example/sig");
+    expect(fetchMock.calls[0].url).toBe("/api/v1/resources/3/download");
+  });
+
+  test("throws when the request fails", async () => {
+    fetchMock.enqueue(() => new Response(null, { status: 500 }));
+    await expect(resourcesApi.getDownloadUrl(3)).rejects.toThrow(
+      "Failed to get download URL",
+    );
+  });
+});

--- a/frontend/src/lib/nav.test.ts
+++ b/frontend/src/lib/nav.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for `isActiveNavLink`, which decides nav-item highlighting in
+ * both the desktop sidebar and the mobile bottom nav.
+ *
+ * Run with: `bun test src/lib/nav.test.ts`
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { isActiveNavLink } from "./nav";
+
+describe("isActiveNavLink", () => {
+  test("root link is active only on exact match", () => {
+    expect(isActiveNavLink("/", "/")).toBe(true);
+    expect(isActiveNavLink("/decks", "/")).toBe(false);
+    expect(isActiveNavLink("/decks/42", "/")).toBe(false);
+    expect(isActiveNavLink("/library", "/")).toBe(false);
+  });
+
+  test("non-root link is active on exact match", () => {
+    expect(isActiveNavLink("/decks", "/decks")).toBe(true);
+    expect(isActiveNavLink("/library", "/library")).toBe(true);
+  });
+
+  test("non-root link is active for nested paths", () => {
+    // Browsing /decks/42 should still highlight the Decks nav item.
+    expect(isActiveNavLink("/decks/42", "/decks")).toBe(true);
+    expect(isActiveNavLink("/decks/42/cards", "/decks")).toBe(true);
+  });
+
+  test("non-root link does NOT match unrelated paths with a shared prefix", () => {
+    // Regression: a naive `startsWith` would (wrongly) match these.
+    expect(isActiveNavLink("/decks-archive", "/decks")).toBe(false);
+    expect(isActiveNavLink("/library-old", "/library")).toBe(false);
+  });
+
+  test("non-matching pathnames return false", () => {
+    expect(isActiveNavLink("/library", "/decks")).toBe(false);
+    expect(isActiveNavLink("/refinery", "/decks")).toBe(false);
+  });
+
+  test("trailing slash on pathname matches under the boundary check", () => {
+    // /decks/ is nested under /decks.
+    expect(isActiveNavLink("/decks/", "/decks")).toBe(true);
+  });
+});

--- a/frontend/src/lib/nav.ts
+++ b/frontend/src/lib/nav.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared helper used by the sidebar and bottom nav to decide whether a
+ * given nav entry is the active one for the current pathname.
+ *
+ * Rule:
+ *   - The root "/" link is active only on an exact match. Otherwise every
+ *     route under the dashboard would highlight it.
+ *   - Every other link is active on exact match OR if the current pathname
+ *     is nested under it, e.g. `/decks/42` should still mark `/decks` as
+ *     active. The boundary check ensures `/decks` does not match
+ *     `/decks-archive`.
+ */
+export function isActiveNavLink(pathname: string, href: string): boolean {
+  if (href === "/") return pathname === "/";
+  if (pathname === href) return true;
+  return pathname.startsWith(`${href}/`);
+}

--- a/frontend/src/lib/test-utils.ts
+++ b/frontend/src/lib/test-utils.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared helpers for unit tests under `bun:test`.
+ *
+ * The tests in this repo deliberately avoid a React/DOM renderer — we test
+ * pure logic, API clients, and small utilities by stubbing `fetch` and
+ * (where needed) `window.location`. These helpers keep that pattern
+ * consistent so each test file does not reinvent its own scaffolding.
+ *
+ * Usage:
+ *
+ *   import { installFetchMock, installWindowMock, restoreGlobals } from "@/lib/test-utils";
+ *
+ *   beforeEach(() => snapshotGlobals());
+ *   afterEach(() => restoreGlobals());
+ *
+ *   test("...", async () => {
+ *     const fetchMock = installFetchMock([
+ *       () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+ *     ]);
+ *     // ... call code that uses fetch ...
+ *     expect(fetchMock.calls[0].url).toBe("/api/v1/decks?limit=100&offset=0");
+ *   });
+ */
+
+export interface FetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+export type FetchHandler = (call: FetchCall) => Response | Promise<Response>;
+
+export interface FetchMock {
+  calls: FetchCall[];
+  /** Append more handlers after the initial set (FIFO order). */
+  enqueue(...handlers: FetchHandler[]): void;
+}
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+/**
+ * Replace `globalThis.fetch` with a FIFO queue of handlers. Each `fetch()`
+ * call consumes the next handler; an unexpected extra call throws so the
+ * test fails loudly rather than silently fetching the network.
+ */
+export function installFetchMock(handlers: FetchHandler[] = []): FetchMock {
+  const calls: FetchCall[] = [];
+  const queue: FetchHandler[] = [...handlers];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const call: FetchCall = { url, init };
+    calls.push(call);
+    const handler = queue.shift();
+    if (!handler) {
+      throw new Error(`Unexpected fetch: ${url}`);
+    }
+    return handler(call);
+  }) as typeof fetch;
+
+  return {
+    calls,
+    enqueue(...more: FetchHandler[]) {
+      queue.push(...more);
+    },
+  };
+}
+
+export function restoreFetch(): void {
+  globalThis.fetch = ORIGINAL_FETCH;
+}
+
+interface InstallWindowOptions {
+  pathname?: string;
+  search?: string;
+  hash?: string;
+}
+
+export interface WindowMock {
+  /** URLs passed to `window.location.replace` since the mock was installed. */
+  replaced: string[];
+}
+
+const ORIGINAL_WINDOW = (globalThis as { window?: Window }).window;
+
+/**
+ * Install a minimal `window` stub for tests that hit `buildLoginUrl` or
+ * other helpers that read `window.location`. Only the fields the code
+ * under test actually touches are populated.
+ */
+export function installWindowMock(opts: InstallWindowOptions = {}): WindowMock {
+  const { pathname = "/", search = "", hash = "" } = opts;
+  const replaced: string[] = [];
+  (globalThis as { window?: unknown }).window = {
+    location: {
+      pathname,
+      search,
+      hash,
+      replace: (url: string) => replaced.push(url),
+    },
+    __replaced: replaced,
+  } as unknown as Window;
+  return { replaced };
+}
+
+export function restoreWindow(): void {
+  if (ORIGINAL_WINDOW === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    (globalThis as { window?: unknown }).window = ORIGINAL_WINDOW;
+  }
+}
+
+/** Helper to build a JSON response with sensible defaults. */
+export function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers as Record<string, string> | undefined),
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Adds a focused frontend test suite covering the load-bearing logic the UI depends on, without introducing a React/DOM renderer. Goes from **21 → 78 tests** across 7 files.

The suite stays close to the project's existing pattern (Bun's built-in test runner, stub `globalThis.fetch`, no jsdom/Testing Library) and **targets behavior that would actually break a user if it regressed** — auth, API contracts, error messages, nav routing — rather than mirroring component internals.

## Test strategy

Decided what to cover by asking: "if this regressed silently, would a user notice?" The matrix below is the answer.

| Area | File | Why it matters |
| --- | --- | --- |
| Middleware redirect / open-redirect safety | `src/proxy.test.ts` *(existing)* | `next=` is user-controlled. |
| Authed fetch + 401 refresh + post-login `next` | `src/lib/api/fetch-with-auth.test.ts` *(existing)* | Every API call goes through this. |
| FastAPI error parsing | `src/lib/api-error.test.ts` *(new)* | Every toast/alert flows through `parseApiError`. |
| Decks / Cards / Resources API clients | `src/lib/api/{decks,cards,resources}.test.ts` *(new)* | Request shape + runtime parsers + error pass-through; a backend response-shape change should fail loudly here, not in the UI. |
| Active-nav highlighting | `src/lib/nav.test.ts` *(new)* | A naive `startsWith` would (wrongly) highlight `/decks` when on `/decks-archive`. Extracted from sidebar + bottom-nav (was duplicated). |

### Explicitly out of scope (with reasoning)

- **Rendered React components / snapshots.** Would require mocking the Next router, auth provider, theme provider, Radix portals, intersection observer, and `sonner` — a lot of brittle scaffolding for tests that mostly re-assert layout, especially under active UI redesign. Where a component has interesting logic, the pure part is extracted (see `isActiveNavLink`) and tested directly.
- **Backend integration.** `globalThis.fetch` is stubbed; we are not verifying FastAPI.
- **Login/Register page submit handlers.** Their non-trivial bits (`parseApiError`-driven error UI) are covered via the `parseApiError` and API-client tests; the React glue around them is one-liners.

`frontend/TESTING.md` documents the same strategy for future contributors, plus the patterns (`installFetchMock`, `installWindowMock`, `__resetForTests`).

### Test infrastructure added

- `src/lib/test-utils.ts` — `installFetchMock`, `installWindowMock`, `jsonResponse`. Consolidates the fetch/window stubbing pattern the existing tests reimplemented inline.
- `src/lib/nav.ts` — extracted `isActiveNavLink` so sidebar + bottom-nav share one source of truth (and one test).
- `package.json` — added `"test": "bun test"` so editor / CI integrations match the other npm scripts.

## Checks run

From `frontend/`:
- `bun test` → **78 pass, 0 fail**, 166 expect() calls (was 21 tests before)
- `bun run lint` → **0 errors** (7 pre-existing warnings in files this PR does not touch)
- `bun run build` → succeeds (all 10 routes build clean, including middleware)

## Test plan

- [x] `bun test` — full suite green
- [x] `bun run lint` — no new errors / warnings
- [x] `bun run build` — production build still succeeds
- [x] Diff inspected — only frontend test files, the extracted `nav.ts` helper, its two callers, `package.json` script, and `TESTING.md`. No backend, no infra, no `docker-compose.yml`.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)