### PR TITLE
fix(frontend): wire session rating buttons

### DIFF
--- a/frontend/src/app/(dashboard)/session/page.tsx
+++ b/frontend/src/app/(dashboard)/session/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/glot/icon";
@@ -49,6 +49,7 @@ export default function SessionPage() {
   const [sessionTotal, setSessionTotal] = useState(0);
   const [reviewedCount, setReviewedCount] = useState(0);
   const [startedAt, setStartedAt] = useState<number>(() => Date.now());
+  const isSubmittingRef = useRef(false);
 
   const currentCard = cards[currentIndex];
   const deckById = useMemo(() => new Map(decks.map((deck) => [deck.id, deck])), [decks]);
@@ -66,6 +67,8 @@ export default function SessionPage() {
     setCurrentIndex(0);
     setSessionTotal(0);
     setReviewedCount(0);
+    setIsSubmitting(false);
+    isSubmittingRef.current = false;
 
     try {
       const [dueCards, allDecks] = await Promise.all([
@@ -97,8 +100,9 @@ export default function SessionPage() {
 
   const handleRate = useCallback(
     async (rating: 1 | 2 | 3 | 4) => {
-      if (!currentCard || isSubmitting) return;
+      if (!currentCard || isSubmittingRef.current) return;
 
+      isSubmittingRef.current = true;
       setIsSubmitting(true);
       setError(null);
       try {
@@ -108,17 +112,18 @@ export default function SessionPage() {
         });
 
         setCards((existingCards) => existingCards.filter((card) => card.id !== currentCard.id));
-        setCurrentIndex((index) => Math.min(index, Math.max(0, cards.length - 2)));
+        setCurrentIndex(0);
         setReviewedCount((count) => Math.min(count + 1, sessionTotal));
         setIsFlipped(false);
         setStartedAt(Date.now());
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to submit review");
       } finally {
+        isSubmittingRef.current = false;
         setIsSubmitting(false);
       }
     },
-    [cards.length, currentCard, isSubmitting, sessionTotal, startedAt]
+    [currentCard, sessionTotal, startedAt]
   );
 
   useEffect(() => {

--- a/frontend/src/app/(dashboard)/session/page.tsx
+++ b/frontend/src/app/(dashboard)/session/page.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/components/glot/icon";
 import { cn } from "@/lib/utils";
 import { cardsApi, type Card } from "@/lib/api/cards";
 import { decksApi, type Deck } from "@/lib/api/decks";
+import { getSessionProgress } from "./session-progress";
 
 const ratingButtons = [
   { label: "Again", rating: 1, shortcut: "1", description: "Retry soon", tone: "bad" as const },
@@ -45,23 +46,26 @@ export default function SessionPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [sessionTotal, setSessionTotal] = useState(0);
+  const [reviewedCount, setReviewedCount] = useState(0);
   const [startedAt, setStartedAt] = useState<number>(() => Date.now());
 
   const currentCard = cards[currentIndex];
   const deckById = useMemo(() => new Map(decks.map((deck) => [deck.id, deck])), [decks]);
   const currentDeck = currentCard?.deck_id ? deckById.get(currentCard.deck_id) : undefined;
-  const totalCards = cards.length;
-  const cardNumber = totalCards === 0 ? 0 : currentIndex + 1;
-  const progressPercent = totalCards === 0 ? 0 : (cardNumber / totalCards) * 100;
-  const remaining = Math.max(0, totalCards - currentIndex);
-  const estimatedMinutes = Math.max(1, Math.round(remaining * 0.25));
+  const { cardNumber, totalCards, progressPercent, estimatedMinutes } = getSessionProgress({
+    sessionTotal,
+    reviewedCount,
+    hasCurrentCard: Boolean(currentCard),
+  });
 
   const loadSession = useCallback(async () => {
     setLoading(true);
     setError(null);
     setIsFlipped(false);
     setCurrentIndex(0);
-    setStartedAt(Date.now());
+    setSessionTotal(0);
+    setReviewedCount(0);
 
     try {
       const [dueCards, allDecks] = await Promise.all([
@@ -70,6 +74,8 @@ export default function SessionPage() {
       ]);
       setCards(dueCards);
       setDecks(allDecks);
+      setSessionTotal(dueCards.length);
+      setStartedAt(Date.now());
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load review session");
     } finally {
@@ -103,6 +109,7 @@ export default function SessionPage() {
 
         setCards((existingCards) => existingCards.filter((card) => card.id !== currentCard.id));
         setCurrentIndex((index) => Math.min(index, Math.max(0, cards.length - 2)));
+        setReviewedCount((count) => Math.min(count + 1, sessionTotal));
         setIsFlipped(false);
         setStartedAt(Date.now());
       } catch (err) {
@@ -111,7 +118,7 @@ export default function SessionPage() {
         setIsSubmitting(false);
       }
     },
-    [cards.length, currentCard, isSubmitting, startedAt]
+    [cards.length, currentCard, isSubmitting, sessionTotal, startedAt]
   );
 
   useEffect(() => {

--- a/frontend/src/app/(dashboard)/session/page.tsx
+++ b/frontend/src/app/(dashboard)/session/page.tsx
@@ -1,26 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/glot/icon";
 import { cn } from "@/lib/utils";
-
-// Mock card data (preserved from prior implementation)
-const mockCard = {
-  id: 1,
-  front: "Ephemeral",
-  back: "Lasting for a very short time; transitory.\n\n'The ephemeral nature of cherry blossoms makes them even more precious.'",
-  deckName: "SAT Vocabulary",
-  cardNumber: 5,
-  totalCards: 23,
-};
+import { cardsApi, type Card } from "@/lib/api/cards";
+import { decksApi, type Deck } from "@/lib/api/decks";
 
 const ratingButtons = [
-  { label: "Again", shortcut: "1", description: "< 1min", tone: "bad" as const },
-  { label: "Hard", shortcut: "2", description: "6min", tone: "warn" as const },
-  { label: "Good", shortcut: "3", description: "10min", tone: "accent" as const },
-  { label: "Easy", shortcut: "4", description: "4d", tone: "info" as const },
+  { label: "Again", rating: 1, shortcut: "1", description: "Retry soon", tone: "bad" as const },
+  { label: "Hard", rating: 2, shortcut: "2", description: "Still hard", tone: "warn" as const },
+  { label: "Good", rating: 3, shortcut: "3", description: "Got it", tone: "accent" as const },
+  { label: "Easy", rating: 4, shortcut: "4", description: "Too easy", tone: "info" as const },
 ];
 
 const TONE_VARS: Record<string, { bg: string; fg: string; border: string }> = {
@@ -30,55 +22,123 @@ const TONE_VARS: Record<string, { bg: string; fg: string; border: string }> = {
   info: { bg: "var(--info)", fg: "#0a0a0b", border: "var(--info)" },
 };
 
-export default function SessionPage() {
-  // Preserved: search params for deck filtering (drives mock title for now)
-  useSearchParams();
+function parseDeckId(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
 
+function formatContent(value: string): string {
+  return value.trim() || "Untitled card";
+}
+
+export default function SessionPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const deckId = parseDeckId(searchParams.get("deck_id"));
+
+  const [cards, setCards] = useState<Card[]>([]);
+  const [decks, setDecks] = useState<Deck[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [startedAt, setStartedAt] = useState<number>(() => Date.now());
 
-  const handleFlip = () => {
-    if (!isAnimating) {
-      setIsAnimating(true);
-      setIsFlipped((f) => !f);
-      setTimeout(() => setIsAnimating(false), 300);
-    }
-  };
+  const currentCard = cards[currentIndex];
+  const deckById = useMemo(() => new Map(decks.map((deck) => [deck.id, deck])), [decks]);
+  const currentDeck = currentCard?.deck_id ? deckById.get(currentCard.deck_id) : undefined;
+  const totalCards = cards.length;
+  const cardNumber = totalCards === 0 ? 0 : currentIndex + 1;
+  const progressPercent = totalCards === 0 ? 0 : (cardNumber / totalCards) * 100;
+  const remaining = Math.max(0, totalCards - currentIndex);
+  const estimatedMinutes = Math.max(1, Math.round(remaining * 0.25));
 
-  const handleRate = (rating: string) => {
+  const loadSession = useCallback(async () => {
+    setLoading(true);
+    setError(null);
     setIsFlipped(false);
-    console.log("Rated:", rating);
-  };
+    setCurrentIndex(0);
+    setStartedAt(Date.now());
 
-  // Keyboard shortcuts (skip when focus is in an input/textarea/select)
+    try {
+      const [dueCards, allDecks] = await Promise.all([
+        cardsApi.getDueCards({ deck_id: deckId, limit: 100 }),
+        decksApi.listDecks(),
+      ]);
+      setCards(dueCards);
+      setDecks(allDecks);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load review session");
+    } finally {
+      setLoading(false);
+    }
+  }, [deckId]);
+
+  useEffect(() => {
+    void loadSession();
+  }, [loadSession]);
+
+  const handleFlip = useCallback(() => {
+    if (!currentCard || isAnimating || isSubmitting) return;
+
+    setIsAnimating(true);
+    setIsFlipped((flipped) => !flipped);
+    window.setTimeout(() => setIsAnimating(false), 300);
+  }, [currentCard, isAnimating, isSubmitting]);
+
+  const handleRate = useCallback(
+    async (rating: 1 | 2 | 3 | 4) => {
+      if (!currentCard || isSubmitting) return;
+
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        await cardsApi.reviewCard(currentCard.id, {
+          rating,
+          review_duration_ms: Date.now() - startedAt,
+        });
+
+        setCards((existingCards) => existingCards.filter((card) => card.id !== currentCard.id));
+        setCurrentIndex((index) => Math.min(index, Math.max(0, cards.length - 2)));
+        setIsFlipped(false);
+        setStartedAt(Date.now());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to submit review");
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [cards.length, currentCard, isSubmitting, startedAt]
+  );
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
       if (e.code === "Space") {
         e.preventDefault();
         handleFlip();
+        return;
       }
+
       if (isFlipped) {
-        const idx = ["1", "2", "3", "4"].indexOf(e.key);
-        if (idx >= 0) handleRate(ratingButtons[idx].label);
+        const button = ratingButtons.find((candidate) => candidate.shortcut === e.key);
+        if (button) void handleRate(button.rating as 1 | 2 | 3 | 4);
       }
     };
+
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFlipped, isAnimating]);
+  }, [handleFlip, handleRate, isFlipped]);
 
-  const progressPercent = (mockCard.cardNumber / mockCard.totalCards) * 100;
-  const remaining = mockCard.totalCards - mockCard.cardNumber + 1;
-  const estimatedMinutes = Math.max(1, Math.round(remaining * 0.25));
+  const deckName = currentDeck?.name ?? (deckId ? "Selected deck" : "Mixed review");
 
   return (
-    <div
-      className="min-h-screen flex flex-col"
-      style={{ background: "var(--bg)" }}
-    >
-      {/* Sticky header */}
+    <div className="h-full min-h-0 -m-4 flex flex-col md:-m-6 lg:-m-8" style={{ background: "var(--bg)" }}>
       <header
         className="sticky top-0 z-30"
         style={{
@@ -89,50 +149,40 @@ export default function SessionPage() {
         }}
       >
         <div className="max-w-3xl mx-auto flex items-center justify-between gap-4 px-4 md:px-6 h-14">
-          <div className="flex items-center gap-2">
-            <Button variant="ghost" size="sm" className="gap-2" onClick={() => window.history.back()}>
-              <Icon name="close" size={14} />
-              <span className="hidden sm:inline">Exit</span>
-            </Button>
-          </div>
+          <Button variant="ghost" size="sm" className="gap-2" onClick={() => router.back()}>
+            <Icon name="close" size={14} />
+            <span className="hidden sm:inline">Exit</span>
+          </Button>
 
           <div className="flex items-center gap-4">
-            <div
-              className="mono"
-              style={{ fontSize: 12, color: "var(--muted)", letterSpacing: "0.04em" }}
-            >
-              <span style={{ color: "var(--fg)", fontWeight: 600 }}>
-                {String(mockCard.cardNumber).padStart(2, "0")}
-              </span>
+            <div className="mono" style={{ fontSize: 12, color: "var(--muted)", letterSpacing: "0.04em" }}>
+              <span style={{ color: "var(--fg)", fontWeight: 600 }}>{String(cardNumber).padStart(2, "0")}</span>
               <span style={{ color: "var(--line-2)", margin: "0 6px" }}>/</span>
-              <span>{String(mockCard.totalCards).padStart(2, "0")}</span>
+              <span>{String(totalCards).padStart(2, "0")}</span>
             </div>
-            <div
-              className="hidden sm:flex items-center gap-1.5"
-              style={{ fontSize: 11, color: "var(--muted)" }}
-            >
+            <div className="hidden sm:flex items-center gap-1.5" style={{ fontSize: 11, color: "var(--muted)" }}>
               <Icon name="clock" size={12} />
               <span className="mono">~{estimatedMinutes}m</span>
             </div>
           </div>
 
           <div className="flex gap-1">
-            <Button variant="ghost" size="icon" aria-label="Flag">
-              <Icon name="flag" size={15} />
+            <Button variant="ghost" size="icon" aria-label="Refresh session" onClick={loadSession} disabled={loading || isSubmitting}>
+              <Icon name="arrowU" size={15} />
             </Button>
-            <Button variant="ghost" size="icon" aria-label="Edit">
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Edit card"
+              disabled={!currentCard?.deck_id}
+              onClick={() => currentCard?.deck_id && router.push(`/decks/${currentCard.deck_id}`)}
+            >
               <Icon name="edit" size={15} />
             </Button>
           </div>
         </div>
 
-        {/* Progress bar */}
-        <div
-          style={{
-            height: 2,
-            background: "var(--surface-1)",
-          }}
-        >
+        <div style={{ height: 2, background: "var(--surface-1)" }}>
           <div
             style={{
               height: "100%",
@@ -145,211 +195,99 @@ export default function SessionPage() {
         </div>
       </header>
 
-      {/* Main */}
       <main className="flex-1 flex flex-col">
-        {/* Deck kicker */}
         <div className="max-w-3xl mx-auto w-full px-4 md:px-6 pt-8 md:pt-12 text-center">
-          <span
-            className="pill outline"
-            style={{ display: "inline-flex" }}
-          >
+          <span className="pill outline" style={{ display: "inline-flex" }}>
             <Icon name="layers" size={11} />
-            {mockCard.deckName}
+            {deckName}
           </span>
         </div>
 
-        {/* Flashcard */}
         <div className="flex-1 flex items-center justify-center px-4 md:px-6 py-10">
-          <div
-            className="perspective-1000 w-full max-w-2xl cursor-pointer"
-            onClick={handleFlip}
-            role="button"
-            aria-label="Flip card"
-          >
+          {loading ? (
+            <div className="glot-card w-full max-w-2xl p-10 text-center" style={{ background: "var(--surface)" }}>
+              <p className="mono" style={{ color: "var(--muted)", letterSpacing: "0.12em" }}>LOADING SESSION</p>
+            </div>
+          ) : error ? (
+            <div className="glot-card w-full max-w-2xl p-10 text-center" style={{ background: "var(--surface)" }}>
+              <p className="mono mb-4" style={{ color: "var(--bad)", letterSpacing: "0.12em" }}>SESSION ERROR</p>
+              <p className="serif mb-6" style={{ color: "var(--fg)", fontSize: 22 }}>{error}</p>
+              <Button onClick={loadSession}>Try again</Button>
+            </div>
+          ) : !currentCard ? (
+            <div className="glot-card w-full max-w-2xl p-10 text-center" style={{ background: "var(--surface)" }}>
+              <p className="mono mb-4" style={{ color: "var(--accent)", letterSpacing: "0.12em" }}>ALL CAUGHT UP</p>
+              <h2 className="serif mb-3" style={{ color: "var(--fg)", fontSize: 36 }}>No cards due right now.</h2>
+              <p className="mb-6" style={{ color: "var(--muted)" }}>Add new cards or come back when more reviews are scheduled.</p>
+              <Button onClick={() => router.push("/decks")}>Back to decks</Button>
+            </div>
+          ) : (
             <div
-              className={cn(
-                "relative w-full preserve-3d transition-transform duration-300",
-                isFlipped && "rotate-y-180"
-              )}
-              style={{ minHeight: "clamp(260px, 40vh, 420px)" }}
+              className={cn("perspective-1000 w-full max-w-2xl", !isFlipped && "cursor-pointer")}
+              onClick={!isFlipped ? handleFlip : undefined}
+              role={!isFlipped ? "button" : undefined}
+              aria-label={!isFlipped ? "Flip card" : undefined}
             >
-              {/* Front */}
-              <div
-                className="absolute inset-0 backface-hidden glot-card flex flex-col items-center justify-center p-10 text-center"
-                style={{
-                  background: "var(--surface)",
-                  boxShadow: "0 30px 80px -40px rgba(0,0,0,0.4)",
-                }}
-              >
-                <div
-                  className="mono mb-6"
-                  style={{ fontSize: 11, color: "var(--muted-2)", letterSpacing: "0.16em" }}
-                >
-                  QUESTION
+              <div className={cn("relative w-full preserve-3d transition-transform duration-300", isFlipped && "rotate-y-180")} style={{ minHeight: "clamp(260px, 40vh, 420px)" }}>
+                <div className="absolute inset-0 backface-hidden glot-card flex flex-col items-center justify-center p-10 text-center" style={{ background: "var(--surface)", boxShadow: "0 30px 80px -40px rgba(0,0,0,0.4)" }}>
+                  <div className="mono mb-6" style={{ fontSize: 11, color: "var(--muted-2)", letterSpacing: "0.16em" }}>QUESTION</div>
+                  <h2 className="serif" style={{ fontSize: "clamp(36px, 6vw, 64px)", fontWeight: 500, lineHeight: 1.1, letterSpacing: "-0.03em", color: "var(--fg)" }}>
+                    {formatContent(currentCard.front_content)}
+                  </h2>
+                  <div className="mt-auto pt-8 mono flex items-center gap-2" style={{ fontSize: 11, color: "var(--muted)", letterSpacing: "0.08em" }}>
+                    TAP OR PRESS <kbd>SPACE</kbd>
+                  </div>
                 </div>
-                <h2
-                  className="serif"
-                  style={{
-                    fontSize: "clamp(40px, 6vw, 64px)",
-                    fontWeight: 500,
-                    lineHeight: 1.1,
-                    letterSpacing: "-0.03em",
-                    color: "var(--fg)",
-                  }}
-                >
-                  {mockCard.front}
-                </h2>
-                <div
-                  className="mt-auto pt-8 mono flex items-center gap-2"
-                  style={{ fontSize: 11, color: "var(--muted)", letterSpacing: "0.08em" }}
-                >
-                  TAP OR PRESS <kbd>SPACE</kbd>
-                </div>
-              </div>
 
-              {/* Back */}
-              <div
-                className="absolute inset-0 backface-hidden rotate-y-180 glot-card flex flex-col items-center justify-center p-10 text-center"
-                style={{
-                  background: "var(--surface)",
-                  borderColor: "color-mix(in oklab, var(--accent) 35%, var(--line))",
-                  boxShadow: "0 30px 80px -40px var(--accent-glow)",
-                }}
-              >
-                <div
-                  className="mono mb-4"
-                  style={{
-                    fontSize: 11,
-                    color: "var(--accent)",
-                    letterSpacing: "0.16em",
-                  }}
-                >
-                  ANSWER
+                <div className="absolute inset-0 backface-hidden rotate-y-180 glot-card flex flex-col items-center justify-center p-10 text-center" style={{ background: "var(--surface)", borderColor: "color-mix(in oklab, var(--accent) 35%, var(--line))", boxShadow: "0 30px 80px -40px var(--accent-glow)" }}>
+                  <div className="mono mb-4" style={{ fontSize: 11, color: "var(--accent)", letterSpacing: "0.16em" }}>ANSWER</div>
+                  <h3 className="serif" style={{ fontSize: 28, fontWeight: 500, color: "var(--accent)", marginBottom: 16 }}>
+                    {formatContent(currentCard.front_content)}
+                  </h3>
+                  <p className="serif whitespace-pre-line max-w-xl" style={{ fontSize: 19, lineHeight: 1.5, color: "var(--fg)", fontWeight: 400 }}>
+                    {formatContent(currentCard.back_content)}
+                  </p>
                 </div>
-                <h3
-                  className="serif"
-                  style={{
-                    fontSize: 28,
-                    fontWeight: 500,
-                    color: "var(--accent)",
-                    marginBottom: 16,
-                  }}
-                >
-                  {mockCard.front}
-                </h3>
-                <p
-                  className="serif whitespace-pre-line max-w-xl"
-                  style={{
-                    fontSize: 19,
-                    lineHeight: 1.5,
-                    color: "var(--fg)",
-                    fontWeight: 400,
-                  }}
-                >
-                  {mockCard.back}
-                </p>
               </div>
             </div>
-          </div>
+          )}
         </div>
 
-        {/* Rating footer */}
-        <div
-          className="px-4 md:px-6 pb-8 pt-4"
-          style={{
-            borderTop: "1px solid var(--line)",
-            background: "var(--bg-1)",
-          }}
-        >
+        <div className="px-4 md:px-6 pb-8 pt-4" style={{ borderTop: "1px solid var(--line)", background: "var(--bg-1)", position: "relative", zIndex: 10 }}>
           <div className="max-w-2xl mx-auto">
-            {isFlipped ? (
+            {currentCard && isFlipped ? (
               <>
-                <div
-                  className="mono text-center mb-3"
-                  style={{
-                    fontSize: 10,
-                    color: "var(--muted-2)",
-                    letterSpacing: "0.16em",
-                  }}
-                >
-                  RATE YOUR RECALL
-                </div>
+                <div className="mono text-center mb-3" style={{ fontSize: 10, color: "var(--muted-2)", letterSpacing: "0.16em" }}>RATE YOUR RECALL</div>
                 <div className="grid grid-cols-4 gap-2">
                   {ratingButtons.map((btn) => {
                     const tone = TONE_VARS[btn.tone];
                     return (
                       <button
                         key={btn.label}
-                        onClick={() => handleRate(btn.label)}
-                        className="focus-glow"
-                        style={{
-                          display: "flex",
-                          flexDirection: "column",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          gap: 2,
-                          padding: "14px 8px",
-                          borderRadius: "var(--radius)",
-                          background: tone.bg,
-                          color: tone.fg,
-                          border: `1px solid ${tone.border}`,
-                          cursor: "pointer",
-                          fontWeight: 600,
-                          transition: "transform .12s ease, filter .15s ease",
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleRate(btn.rating as 1 | 2 | 3 | 4);
                         }}
-                        onMouseEnter={(e) =>
-                          (e.currentTarget.style.filter = "brightness(1.05)")
-                        }
-                        onMouseLeave={(e) =>
-                          (e.currentTarget.style.filter = "brightness(1)")
-                        }
+                        disabled={isSubmitting}
+                        className="focus-glow"
+                        style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 2, padding: "14px 8px", borderRadius: "var(--radius)", background: tone.bg, color: tone.fg, border: `1px solid ${tone.border}`, cursor: isSubmitting ? "wait" : "pointer", fontWeight: 600, opacity: isSubmitting ? 0.7 : 1 }}
                       >
                         <span style={{ fontSize: 14 }}>{btn.label}</span>
-                        <span
-                          className="mono"
-                          style={{
-                            fontSize: 10,
-                            opacity: 0.75,
-                            letterSpacing: "0.04em",
-                          }}
-                        >
-                          {btn.description}
-                        </span>
-                        <kbd
-                          style={{
-                            marginTop: 4,
-                            background: "rgba(0,0,0,0.15)",
-                            color: "inherit",
-                            border: "1px solid rgba(0,0,0,0.15)",
-                          }}
-                        >
-                          {btn.shortcut}
-                        </kbd>
+                        <span className="mono" style={{ fontSize: 10, opacity: 0.75, letterSpacing: "0.04em" }}>{btn.description}</span>
+                        <kbd style={{ marginTop: 4, background: "rgba(0,0,0,0.15)", color: "inherit", border: "1px solid rgba(0,0,0,0.15)" }}>{btn.shortcut}</kbd>
                       </button>
                     );
                   })}
                 </div>
               </>
-            ) : (
+            ) : currentCard ? (
               <div className="flex justify-center">
-                <Button
-                  size="lg"
-                  className="px-12 gap-2"
-                  onClick={handleFlip}
-                >
+                <Button size="lg" className="px-12 gap-2" onClick={handleFlip} disabled={isSubmitting}>
                   Show answer
-                  <kbd
-                    style={{
-                      background: "rgba(0,0,0,0.15)",
-                      color: "inherit",
-                      border: "1px solid rgba(0,0,0,0.2)",
-                    }}
-                  >
-                    SPACE
-                  </kbd>
+                  <kbd style={{ background: "rgba(0,0,0,0.15)", color: "inherit", border: "1px solid rgba(0,0,0,0.2)" }}>SPACE</kbd>
                 </Button>
               </div>
-            )}
+            ) : null}
           </div>
         </div>
       </main>

--- a/frontend/src/app/(dashboard)/session/session-progress.ts
+++ b/frontend/src/app/(dashboard)/session/session-progress.ts
@@ -1,0 +1,42 @@
+export type SessionProgress = {
+  cardNumber: number;
+  totalCards: number;
+  progressPercent: number;
+  remaining: number;
+  estimatedMinutes: number;
+};
+
+export function getSessionProgress({
+  sessionTotal,
+  reviewedCount,
+  hasCurrentCard,
+}: {
+  sessionTotal: number;
+  reviewedCount: number;
+  hasCurrentCard: boolean;
+}): SessionProgress {
+  const totalCards = Math.max(0, sessionTotal);
+  const completed = Math.min(Math.max(0, reviewedCount), totalCards);
+
+  if (totalCards === 0) {
+    return {
+      cardNumber: 0,
+      totalCards: 0,
+      progressPercent: 0,
+      remaining: 0,
+      estimatedMinutes: 1,
+    };
+  }
+
+  const remaining = hasCurrentCard ? totalCards - completed : 0;
+  const cardNumber = hasCurrentCard ? Math.min(completed + 1, totalCards) : totalCards;
+  const progressPosition = hasCurrentCard ? cardNumber : totalCards;
+
+  return {
+    cardNumber,
+    totalCards,
+    progressPercent: (progressPosition / totalCards) * 100,
+    remaining,
+    estimatedMinutes: Math.max(1, Math.round(remaining * 0.25)),
+  };
+}

--- a/frontend/src/app/(dashboard)/session/session.test.ts
+++ b/frontend/src/app/(dashboard)/session/session.test.ts
@@ -27,6 +27,7 @@ import {
   type Card,
   type NextStatesResponse,
 } from "@/lib/api/cards";
+import { getSessionProgress } from "./session-progress";
 import {
   installFetchMock,
   installWindowMock,
@@ -74,6 +75,42 @@ beforeEach(() => {
 afterEach(() => {
   restoreFetch();
   restoreWindow();
+});
+
+describe("session — progress display", () => {
+  test("keeps the original session total while advancing through reviewed cards", () => {
+    const firstCard = getSessionProgress({ sessionTotal: 3, reviewedCount: 0, hasCurrentCard: true });
+    expect(firstCard).toMatchObject({
+      cardNumber: 1,
+      totalCards: 3,
+      remaining: 3,
+    });
+    expect(firstCard.progressPercent).toBeCloseTo(100 / 3);
+
+    const secondCard = getSessionProgress({ sessionTotal: 3, reviewedCount: 1, hasCurrentCard: true });
+    expect(secondCard).toMatchObject({
+      cardNumber: 2,
+      totalCards: 3,
+      remaining: 2,
+    });
+    expect(secondCard.progressPercent).toBeCloseTo(200 / 3);
+
+    expect(getSessionProgress({ sessionTotal: 3, reviewedCount: 3, hasCurrentCard: false })).toMatchObject({
+      cardNumber: 3,
+      totalCards: 3,
+      progressPercent: 100,
+      remaining: 0,
+    });
+  });
+
+  test("shows zero progress for an empty session", () => {
+    expect(getSessionProgress({ sessionTotal: 0, reviewedCount: 0, hasCurrentCard: false })).toMatchObject({
+      cardNumber: 0,
+      totalCards: 0,
+      progressPercent: 0,
+      remaining: 0,
+    });
+  });
 });
 
 describe("session — due-card loading", () => {

--- a/frontend/src/app/(dashboard)/session/session.test.ts
+++ b/frontend/src/app/(dashboard)/session/session.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Session page — API contract tests.
+ *
+ * The project does not have a React/DOM render environment, so these tests
+ * guard the API layer as the session page uses it rather than testing the
+ * component directly. They are colocated with the session page so they are
+ * easy to extend when component-level tests become feasible.
+ *
+ * What is covered:
+ *   - getDueCards with limit:100 (the session overrides the API default of 20)
+ *   - getDueCards with and without deck_id (single-deck vs mixed-review modes)
+ *   - Empty due-cards list (the "All caught up" state)
+ *   - reviewCard sends all four rating values (1-4) plus review_duration_ms
+ *   - reviewCard failure surfaces a meaningful error message
+ *
+ * What is NOT covered here (requires a DOM/React render environment):
+ *   - Rating buttons are visible only after the card is flipped
+ *   - Clicking a rating button calls reviewCard and advances the session
+ *   - Keyboard shortcuts 1-4 trigger the correct rating exactly once
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { __resetForTests } from "@/lib/api/fetch-with-auth";
+import {
+  cardsApi,
+  type Card,
+  type NextStatesResponse,
+} from "@/lib/api/cards";
+import {
+  installFetchMock,
+  installWindowMock,
+  jsonResponse,
+  restoreFetch,
+  restoreWindow,
+  type FetchMock,
+} from "@/lib/test-utils";
+
+function makeCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: 1,
+    sequence: 1,
+    front_content: "Q",
+    back_content: "A",
+    meta_data: {},
+    tags: [],
+    deck_id: 5,
+    difficulty: 0.3,
+    stability: 4.0,
+    state: "review",
+    reps: 3,
+    lapses: 0,
+    last_review_at: "2026-05-10T10:00:00Z",
+    next_review_at: "2026-05-17T10:00:00Z",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-05-10T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeNextStates(): NextStatesResponse {
+  const info = { interval_days: 1, new_difficulty: 0.3, new_stability: 1.5 };
+  return { again: info, hard: info, good: info, easy: info };
+}
+
+let fetchMock: FetchMock;
+
+beforeEach(() => {
+  __resetForTests();
+  installWindowMock();
+  fetchMock = installFetchMock();
+});
+
+afterEach(() => {
+  restoreFetch();
+  restoreWindow();
+});
+
+describe("session — due-card loading", () => {
+  test("requests limit:100 for a deck-specific session (not the API default of 20)", async () => {
+    fetchMock.enqueue(() => jsonResponse([makeCard()]));
+
+    const cards = await cardsApi.getDueCards({ deck_id: 5, limit: 100 });
+
+    expect(cards).toHaveLength(1);
+    const url = new URL(fetchMock.calls[0].url, "http://localhost");
+    expect(url.searchParams.get("deck_id")).toBe("5");
+    expect(url.searchParams.get("limit")).toBe("100");
+  });
+
+  test("omits deck_id and requests limit:100 for a mixed-review session", async () => {
+    fetchMock.enqueue(() => jsonResponse([makeCard(), makeCard({ id: 2 })]));
+
+    const cards = await cardsApi.getDueCards({ limit: 100 });
+
+    expect(cards).toHaveLength(2);
+    expect(fetchMock.calls[0].url).toBe("/api/v1/cards/due?limit=100");
+  });
+
+  test("returns an empty array when no cards are due", async () => {
+    fetchMock.enqueue(() => jsonResponse([]));
+
+    const cards = await cardsApi.getDueCards({ limit: 100 });
+
+    expect(cards).toHaveLength(0);
+  });
+});
+
+describe("session — rating a card", () => {
+  test.each([1, 2, 3, 4] as const)(
+    "rating %i is forwarded verbatim with review_duration_ms",
+    async (rating) => {
+      fetchMock.enqueue(() =>
+        jsonResponse({
+          card: makeCard(),
+          next_states: makeNextStates(),
+          message: "ok",
+        }),
+      );
+
+      await cardsApi.reviewCard(1, { rating, review_duration_ms: 5000 });
+
+      const call = fetchMock.calls[0];
+      expect(call.url).toBe("/api/v1/cards/1/review");
+      expect(call.init?.method).toBe("POST");
+      const body = JSON.parse(call.init?.body as string);
+      expect(body.rating).toBe(rating);
+      expect(body.review_duration_ms).toBe(5000);
+    },
+  );
+
+  test("surfaces the API error detail when the review request fails", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({ detail: "Card not found" }, { status: 404 }),
+    );
+
+    await expect(
+      cardsApi.reviewCard(999, { rating: 1, review_duration_ms: 1000 }),
+    ).rejects.toThrow("Card not found");
+  });
+});


### PR DESCRIPTION
## Summary
- Loads real due cards for review sessions instead of mock data.
- Wires Again/Hard/Good/Easy buttons and 1–4 shortcuts to the review API.
- Prevents the flipped card layer from intercepting rating clicks and keeps the footer accessible.

## Root cause
The session UI still used local mock data and did not submit rating actions through the backend review endpoint, so mouse rating clicks did not complete the real end-to-end review flow.

## Verification
- bun test
- bun run lint
- bun run build
- Docker production build
- Browser-tested login, session load, Space flip, mouse rating, keyboard rating, and backend POST review logs

Closes #74
