### PR TITLE
fix(backend): bcrypt-to-argon2 migration and deploy fixes

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -34,6 +34,7 @@ from app.core.security import (
     generate_refresh_token,
     hash_password,
     hash_refresh_token,
+    needs_rehash,
     parse_device_name,
     verify_password,
 )
@@ -169,6 +170,12 @@ async def login(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
         )
+
+    # Transparent migration: if the stored hash is bcrypt or weak Argon2,
+    # rehash with current Argon2 defaults on successful login.
+    if needs_rehash(user.password_hash):
+        user.password_hash = hash_password(login_data.password)
+        logger.info(f"Password hash upgraded to Argon2 for user: {user.email}")
 
     if not user.is_active:
         raise HTTPException(
@@ -377,7 +384,7 @@ async def change_password(
             detail="Current password is incorrect",
         )
 
-    # Update password
+    # Update password (always uses Argon2)
     current_user.password_hash = hash_password(password_data.new_password)
 
     logger.info(f"Password changed for user: {current_user.email}")

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -171,17 +171,19 @@ async def login(
             detail="Invalid email or password",
         )
 
-    # Transparent migration: if the stored hash is bcrypt or weak Argon2,
-    # rehash with current Argon2 defaults on successful login.
-    if needs_rehash(user.password_hash):
-        user.password_hash = hash_password(login_data.password)
-        logger.info(f"Password hash upgraded to Argon2 for user: {user.email}")
-
     if not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Your account is awaiting admin approval.",
         )
+
+    # Transparent migration: if the stored hash is bcrypt or weak Argon2,
+    # rehash with current Argon2 defaults on successful login.
+    # Must run after is_active check so inactive users don't trigger a
+    # false "upgraded" log (their session gets rolled back anyway).
+    if needs_rehash(user.password_hash):
+        user.password_hash = hash_password(login_data.password)
+        logger.info(f"Password hash upgraded to Argon2 for user: {user.email}")
 
     # Update last login
     user.last_login_at = datetime.now(UTC)

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -2,6 +2,7 @@
 Core configuration and settings for the Glot backend.
 """
 
+import json
 from functools import lru_cache
 
 from pydantic import field_validator
@@ -72,6 +73,19 @@ class Settings(BaseSettings):
         """Require a non-empty JWT secret."""
         if not value.strip():
             raise ValueError("JWT_SECRET must not be blank")
+        return value
+
+    @field_validator("cors_origins", "resource_allowed_types", mode="before")
+    @classmethod
+    def parse_json_list(cls, value):
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+                if isinstance(parsed, list):
+                    return parsed
+            except json.JSONDecodeError:
+                # Fallback: treat comma-separated string as list
+                return [item.strip() for item in value.split(",") if item.strip()]
         return value
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime, timedelta
 
 import jwt
 from argon2 import PasswordHasher
-from argon2.exceptions import VerifyMismatchError
+from argon2.exceptions import InvalidHashError, VerifyMismatchError
 from user_agents import parse as parse_user_agent
 
 from app.core import get_settings
@@ -38,9 +38,13 @@ def _verify_bcrypt(plain_password: str, hashed_password: str) -> bool:
     """Verify a password against a bcrypt hash (legacy migration path)."""
     import bcrypt  # lazy — only imported when needed
 
-    return bcrypt.checkpw(
-        plain_password.encode("utf-8"), hashed_password.encode("utf-8")
-    )
+    try:
+        return bcrypt.checkpw(
+            plain_password.encode("utf-8"), hashed_password.encode("utf-8")
+        )
+    except (ValueError, TypeError):
+        # Malformed hash (e.g. truncated, bad salt) — treat as verification failure
+        return False
 
 # Password validation constants
 PASSWORD_MIN_LENGTH = 8
@@ -70,17 +74,24 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
         return True
     except VerifyMismatchError:
         return False
+    except InvalidHashError:
+        # Corrupted or unrecognized hash — treat as verification failure
+        return False
 
 
 def needs_rehash(hashed_password: str) -> bool:
     """Return True if the stored hash should be upgraded to Argon2.
 
     True for bcrypt hashes and for Argon2 hashes whose parameters are
-    weaker than the current PasswordHasher defaults.
+    weaker than the current PasswordHasher defaults.  Returns False for
+    corrupted/unrecognized hashes (no point rehashing garbage).
     """
     if _is_bcrypt_hash(hashed_password):
         return True
-    return ph.check_needs_rehash(hashed_password)
+    try:
+        return ph.check_needs_rehash(hashed_password)
+    except InvalidHashError:
+        return False
 
 
 def validate_password_strength(password: str) -> str:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -24,13 +24,14 @@ from app.core import get_settings
 ph = PasswordHasher()
 
 # Legacy bcrypt support — existing users may still have bcrypt hashes.
-# Detected by the "$2b$" prefix.  On successful bcrypt login the caller
-# should rehash with Argon2 so the migration is gradual and transparent.
-BCRYPT_PREFIX = "$2b$"
+# Detected by the "$2b$" prefix (also matches $2a$/$2x$/$2y$ variants).
+# On successful bcrypt login the caller should rehash with Argon2 so the
+# migration is gradual and transparent.
+BCRYPT_PREFIXES = ("$2a$", "$2b$", "$2x$", "$2y$")
 
 
 def _is_bcrypt_hash(hashed: str) -> bool:
-    return hashed.startswith(BCRYPT_PREFIX)
+    return hashed.startswith(BCRYPT_PREFIXES)
 
 
 def _verify_bcrypt(plain_password: str, hashed_password: str) -> bool:
@@ -59,13 +60,15 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     a successful verification — if True, the stored hash should be replaced
     with a fresh Argon2 hash (transparent migration from bcrypt → Argon2).
     """
+    # Short-circuit: if the hash looks like bcrypt, go straight to bcrypt
+    # verification.  Passing a bcrypt hash to ph.verify() raises
+    # InvalidHashError (not VerifyMismatchError), which would escape uncaught.
+    if _is_bcrypt_hash(hashed_password):
+        return _verify_bcrypt(plain_password, hashed_password)
     try:
         ph.verify(hashed_password, plain_password)
         return True
     except VerifyMismatchError:
-        # Not a matching Argon2 hash — try bcrypt fallback
-        if _is_bcrypt_hash(hashed_password):
-            return _verify_bcrypt(plain_password, hashed_password)
         return False
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -23,6 +23,24 @@ from app.core import get_settings
 # Password hashing with Argon2 (no length limits, modern algorithm)
 ph = PasswordHasher()
 
+# Legacy bcrypt support — existing users may still have bcrypt hashes.
+# Detected by the "$2b$" prefix.  On successful bcrypt login the caller
+# should rehash with Argon2 so the migration is gradual and transparent.
+BCRYPT_PREFIX = "$2b$"
+
+
+def _is_bcrypt_hash(hashed: str) -> bool:
+    return hashed.startswith(BCRYPT_PREFIX)
+
+
+def _verify_bcrypt(plain_password: str, hashed_password: str) -> bool:
+    """Verify a password against a bcrypt hash (legacy migration path)."""
+    import bcrypt  # lazy — only imported when needed
+
+    return bcrypt.checkpw(
+        plain_password.encode("utf-8"), hashed_password.encode("utf-8")
+    )
+
 # Password validation constants
 PASSWORD_MIN_LENGTH = 8
 PASSWORD_MAX_LENGTH = 128  # Argon2 has no practical limit
@@ -35,12 +53,31 @@ def hash_password(password: str) -> str:
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Verify a password against its Argon2 hash."""
+    """Verify a password against its hash (Argon2 or legacy bcrypt).
+
+    Returns True on success.  Callers should check `needs_rehash()` after
+    a successful verification — if True, the stored hash should be replaced
+    with a fresh Argon2 hash (transparent migration from bcrypt → Argon2).
+    """
     try:
         ph.verify(hashed_password, plain_password)
         return True
     except VerifyMismatchError:
+        # Not a matching Argon2 hash — try bcrypt fallback
+        if _is_bcrypt_hash(hashed_password):
+            return _verify_bcrypt(plain_password, hashed_password)
         return False
+
+
+def needs_rehash(hashed_password: str) -> bool:
+    """Return True if the stored hash should be upgraded to Argon2.
+
+    True for bcrypt hashes and for Argon2 hashes whose parameters are
+    weaker than the current PasswordHasher defaults.
+    """
+    if _is_bcrypt_hash(hashed_password):
+        return True
+    return ph.check_needs_rehash(hashed_password)
 
 
 def validate_password_strength(password: str) -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "slowapi>=0.1.9",
     "user-agents>=2.2.0",
     "argon2-cffi>=25.1.0",
+    "bcrypt>=4.0.0",
     "boto3>=1.42.19",
     "arq>=0.26.3",
     "redis>=5.3.1",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 DEPLOY_DIR="$HOME/glot"
 COMPOSE_FILE="$DEPLOY_DIR/docker-compose.prod.yml"
 
+cd "$DEPLOY_DIR"
+
 # Accept optional GLOT_VERSION env var (semver from CI, e.g. 0.2.0)
 # Falls back to :latest if not set
 export GLOT_VERSION="${GLOT_VERSION:-latest}"


### PR DESCRIPTION
**Problem:** The Argon2 auth overhaul broke login for existing users with bcrypt password hashes — `verify_password` only checks Argon2. Also `deploy.sh` doesn't cd into `~/glot`, so compose may not resolve `.env`/Caddyfile paths. The `parse_json_list` validator for `cors_origins`/`resource_allowed_types` was missed from a previous PR.

**Key changes:**
- Add bcrypt fallback detection (`b$` prefix) in `verify_password`
- Auto-upgrade bcrypt hashes to Argon2 on successful login (transparent migration)
- Add `needs_rehash()` helper for migration detection
- Add `bcrypt>=4.0.0` dependency
- Fix `deploy.sh` to `cd "$DEPLOY_DIR"` before compose operations
- Add `parse_json_list` pydantic validator for list-valued env vars

**Impact:** Existing users can log in after deploy — their bcrypt hashes work and get upgraded to Argon2 on first successful login. Deploy script now correctly resolves all file paths from `~/glot`.