### PR TITLE
fix(infra): stop containers before deploy to avoid name conflicts

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -117,5 +117,4 @@ jobs:
           printf '%s\n' "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           printf '%s\n' "${{ secrets.DEPLOY_HOSTKEY }}" >> ~/.ssh/known_hosts
-          scp -i ~/.ssh/deploy_key -o "UserKnownHostsFile=~/.ssh/known_hosts" scripts/deploy.sh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:~/deploy.sh
-          ssh -i ~/.ssh/deploy_key -o "UserKnownHostsFile=~/.ssh/known_hosts" ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "GLOT_VERSION=$GLOT_VERSION REGISTRY_TOKEN='$REGISTRY_TOKEN' ~/deploy.sh"
+          ssh -i ~/.ssh/deploy_key -o "UserKnownHostsFile=~/.ssh/known_hosts" ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "GLOT_VERSION=$GLOT_VERSION REGISTRY_TOKEN='$REGISTRY_TOKEN'" bash < scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,25 +12,28 @@ export GLOT_VERSION="${GLOT_VERSION:-latest}"
 
 echo "=== Glot Deploy (version: $GLOT_VERSION) ==="
 
-echo "[1/7] Logging in to GHCR..."
+echo "[1/8] Logging in to GHCR..."
 echo "$REGISTRY_TOKEN" | docker login ghcr.io -u hsilabot --password-stdin
 
-echo "[2/7] Capturing current image tags for rollback..."
+echo "[2/8] Capturing current image tags for rollback..."
 OLD_BACKEND_TAG=$(docker inspect --format='{{.Config.Image}}' glot-backend 2>/dev/null || echo "none")
 OLD_FRONTEND_TAG=$(docker inspect --format='{{.Config.Image}}' glot-frontend 2>/dev/null || echo "none")
 echo "  Previous backend: $OLD_BACKEND_TAG"
 echo "  Previous frontend: $OLD_FRONTEND_TAG"
 
-echo "[3/7] Pulling images (tag: $GLOT_VERSION)..."
+echo "[3/8] Stopping and removing old containers..."
+docker compose -f "$COMPOSE_FILE" down --remove-orphans || true
+
+echo "[4/8] Pulling images (tag: $GLOT_VERSION)..."
 docker compose -f "$COMPOSE_FILE" pull
 
-echo "[4/7] Running database migrations..."
+echo "[5/8] Running database migrations..."
 docker compose -f "$COMPOSE_FILE" run --rm backend uv run alembic upgrade head
 
-echo "[5/7] Restarting services..."
+echo "[6/8] Starting services..."
 docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
 
-echo "[6/7] Health check..."
+echo "[7/8] Health check..."
 HEALTH_OK=false
 for i in $(seq 1 30); do
   if curl -sf http://127.0.0.1:8000/docs > /dev/null 2>&1; then
@@ -54,7 +57,7 @@ if [ "$HEALTH_OK" = "false" ]; then
   exit 1
 fi
 
-echo "[7/7] Cleaning old images..."
+echo "[8/8] Cleaning old images..."
 docker image prune -a -f
 
 echo "=== Deploy complete ==="

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,28 +10,31 @@ cd "$DEPLOY_DIR"
 exec 9>/tmp/glot-deploy.lock
 flock -n 9 || { echo "Deploy already in progress — aborting"; exit 1; }
 
+# Validate required env vars before doing anything
+: "${REGISTRY_TOKEN:?must be set in environment}"
+
 # Accept optional GLOT_VERSION env var (semver from CI, e.g. 0.2.0)
 # Falls back to :latest if not set
 export GLOT_VERSION="${GLOT_VERSION:-latest}"
 
 echo "=== Glot Deploy (version: $GLOT_VERSION) ==="
 
-echo "[1/8] Logging in to GHCR..."
+echo "[1/9] Logging in to GHCR..."
 echo "$REGISTRY_TOKEN" | docker login ghcr.io -u hsilabot --password-stdin
 
-echo "[2/8] Pulling images (tag: $GLOT_VERSION)..."
+echo "[2/9] Pulling images (tag: $GLOT_VERSION)..."
 docker compose -f "$COMPOSE_FILE" pull
 
-echo "[3/8] Stopping and removing old containers..."
+echo "[3/9] Stopping and removing old containers..."
 docker compose -f "$COMPOSE_FILE" down --remove-orphans
 
-echo "[4/8] Running database migrations..."
+echo "[4/9] Running database migrations..."
 docker compose -f "$COMPOSE_FILE" run --rm backend uv run alembic upgrade head
 
-echo "[5/8] Starting services..."
+echo "[5/9] Starting services..."
 docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
 
-echo "[6/8] Health check (backend)..."
+echo "[6/9] Health check (backend)..."
 HEALTH_OK=false
 for i in $(seq 1 30); do
   if curl -sf http://127.0.0.1:8000/docs > /dev/null 2>&1; then
@@ -53,7 +56,7 @@ if [ "$HEALTH_OK" = "false" ]; then
   exit 1
 fi
 
-echo "[7/8] Health check (frontend)..."
+echo "[7/9] Health check (frontend)..."
 FRONTEND_OK=false
 for i in $(seq 1 15); do
   if curl -sf http://127.0.0.1:3000 > /dev/null 2>&1; then
@@ -73,7 +76,15 @@ if [ "$FRONTEND_OK" = "false" ]; then
   exit 1
 fi
 
-echo "[8/8] Cleaning old images..."
+echo "[8/9] Health check (worker)..."
+if ! docker compose -f "$COMPOSE_FILE" ps --status running --services 2>/dev/null | grep -q '^worker$'; then
+  echo "  ✗ Worker not running"
+  docker compose -f "$COMPOSE_FILE" logs --tail=50 worker
+  exit 1
+fi
+echo "  ✓ Worker is running"
+
+echo "[9/9] Cleaning old images..."
 docker image prune -a -f
 
 echo "=== Deploy complete ==="

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,6 +6,10 @@ COMPOSE_FILE="$DEPLOY_DIR/docker-compose.prod.yml"
 
 cd "$DEPLOY_DIR"
 
+# Prevent concurrent deploys
+exec 9>/tmp/glot-deploy.lock
+flock -n 9 || { echo "Deploy already in progress — aborting"; exit 1; }
+
 # Accept optional GLOT_VERSION env var (semver from CI, e.g. 0.2.0)
 # Falls back to :latest if not set
 export GLOT_VERSION="${GLOT_VERSION:-latest}"
@@ -15,25 +19,19 @@ echo "=== Glot Deploy (version: $GLOT_VERSION) ==="
 echo "[1/8] Logging in to GHCR..."
 echo "$REGISTRY_TOKEN" | docker login ghcr.io -u hsilabot --password-stdin
 
-echo "[2/8] Capturing current image tags for rollback..."
-OLD_BACKEND_TAG=$(docker inspect --format='{{.Config.Image}}' glot-backend 2>/dev/null || echo "none")
-OLD_FRONTEND_TAG=$(docker inspect --format='{{.Config.Image}}' glot-frontend 2>/dev/null || echo "none")
-echo "  Previous backend: $OLD_BACKEND_TAG"
-echo "  Previous frontend: $OLD_FRONTEND_TAG"
-
-echo "[3/8] Stopping and removing old containers..."
-docker compose -f "$COMPOSE_FILE" down --remove-orphans || true
-
-echo "[4/8] Pulling images (tag: $GLOT_VERSION)..."
+echo "[2/8] Pulling images (tag: $GLOT_VERSION)..."
 docker compose -f "$COMPOSE_FILE" pull
 
-echo "[5/8] Running database migrations..."
+echo "[3/8] Stopping and removing old containers..."
+docker compose -f "$COMPOSE_FILE" down --remove-orphans
+
+echo "[4/8] Running database migrations..."
 docker compose -f "$COMPOSE_FILE" run --rm backend uv run alembic upgrade head
 
-echo "[6/8] Starting services..."
+echo "[5/8] Starting services..."
 docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
 
-echo "[7/8] Health check..."
+echo "[6/8] Health check (backend)..."
 HEALTH_OK=false
 for i in $(seq 1 30); do
   if curl -sf http://127.0.0.1:8000/docs > /dev/null 2>&1; then
@@ -48,12 +46,30 @@ for i in $(seq 1 30); do
 done
 
 if [ "$HEALTH_OK" = "false" ]; then
-  echo "  ✗ Deploy failed — rolling back..."
+  echo "  ✗ Deploy failed — backend unhealthy"
   docker compose -f "$COMPOSE_FILE" logs --tail=50 backend
-  if [ "$OLD_BACKEND_TAG" != "none" ]; then
-    echo "  Reverting to previous images..."
-    GLOT_VERSION="${OLD_BACKEND_TAG#*:}" docker compose -f "$COMPOSE_FILE" up -d
+  # Do not rollback: alembic already migrated the DB, old code may conflict
+  # with the new schema.  Leave containers down and alert.
+  exit 1
+fi
+
+echo "[7/8] Health check (frontend)..."
+FRONTEND_OK=false
+for i in $(seq 1 15); do
+  if curl -sf http://127.0.0.1:3000 > /dev/null 2>&1; then
+    echo "  ✓ Frontend is healthy"
+    FRONTEND_OK=true
+    break
   fi
+  if [ "$i" -eq 15 ]; then
+    echo "  ✗ Frontend health check failed after 15 attempts"
+  fi
+  sleep 2
+done
+
+if [ "$FRONTEND_OK" = "false" ]; then
+  echo "  ✗ Deploy failed — frontend unhealthy"
+  docker compose -f "$COMPOSE_FILE" logs --tail=50 frontend
   exit 1
 fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -84,7 +84,8 @@ if ! docker compose -f "$COMPOSE_FILE" ps --status running --services 2>/dev/nul
 fi
 echo "  ✓ Worker is running"
 
-echo "[9/9] Cleaning old images..."
+echo "[9/9] Cleaning old images and build cache..."
 docker image prune -a -f
+docker builder prune -f
 
 echo "=== Deploy complete ==="


### PR DESCRIPTION
Prevents deploy failures caused by already-existing container names when the deploy job retries or previously created containers were not removed. Adds `docker compose down` before pulling images and running migrations.