### PR TITLE
feat(frontend): requeue failed cards during study sessions

### DIFF
--- a/backend/app/services/fsrs_service.py
+++ b/backend/app/services/fsrs_service.py
@@ -22,6 +22,11 @@ from fsrs_rs_python import DEFAULT_PARAMETERS, FSRS, MemoryState
 from app.models.card import Card, CardState
 from app.schemas.card import NextStatesResponse, SchedulingInfo
 
+# Rating Again should keep the failed card due immediately today. The frontend
+# controls active-session spacing; this persisted timestamp preserves the retry
+# if the browser session is interrupted.
+AGAIN_RETRY_DELAY = timedelta(0)
+
 if TYPE_CHECKING:
     from fsrs_rs_python import NextStates
 
@@ -156,7 +161,9 @@ class FSRSService:
         }
         selected_state = rating_map[rating]
 
-        # Calculate new interval (capped by maximum)
+        # Calculate new interval (capped by maximum). Passing ratings stay on the
+        # existing day-based schedule; Again is persisted as due immediately so
+        # an interrupted session still surfaces the failed card today.
         interval_days = min(
             int(max(1, round(selected_state.interval))),
             self.maximum_interval_days,
@@ -179,7 +186,10 @@ class FSRSService:
         # Update timestamps
         now = datetime.now(UTC)
         card.last_review_at = now
-        card.next_review_at = now + timedelta(days=interval_days)
+        if rating == 1:
+            card.next_review_at = now + AGAIN_RETRY_DELAY
+        else:
+            card.next_review_at = now + timedelta(days=interval_days)
         card.updated_at = now
 
         return card, scheduled_days, elapsed_days

--- a/backend/tests/test_fsrs_service.py
+++ b/backend/tests/test_fsrs_service.py
@@ -1,0 +1,61 @@
+from datetime import UTC, datetime, timedelta
+
+from app.models.card import Card, CardState
+from app.services.fsrs_service import AGAIN_RETRY_DELAY, FSRSService
+
+
+def make_card(**overrides) -> Card:
+    values = {
+        "sequence": 1,
+        "deck_id": 1,
+        "front_content": "bonjour",
+        "back_content": "hello",
+    }
+    values.update(overrides)
+    return Card(**values)
+
+
+def test_again_keeps_card_due_immediately_today():
+    service = FSRSService()
+    card = make_card(state=CardState.REVIEW, stability=2.0, difficulty=5.0, reps=3)
+
+    before = datetime.now(UTC)
+    updated, _scheduled_days, _elapsed_days = service.apply_review(card, rating=1)
+    after = datetime.now(UTC)
+
+    assert updated.state == CardState.RELEARNING
+    assert updated.lapses == 1
+    assert updated.reps == 4
+    assert updated.last_review_at is not None
+    assert updated.next_review_at is not None
+    assert before <= updated.next_review_at <= after + AGAIN_RETRY_DELAY
+
+
+def test_passing_rating_keeps_day_based_schedule():
+    service = FSRSService()
+    card = make_card(state=CardState.REVIEW, stability=2.0, difficulty=5.0, reps=3)
+
+    updated, _scheduled_days, _elapsed_days = service.apply_review(card, rating=3)
+
+    assert updated.state == CardState.REVIEW
+    assert updated.last_review_at is not None
+    assert updated.next_review_at is not None
+    assert updated.next_review_at - updated.last_review_at >= timedelta(days=1)
+
+
+def test_passing_after_again_graduates_out_of_immediate_retry():
+    service = FSRSService()
+    card = make_card(state=CardState.REVIEW, stability=2.0, difficulty=5.0, reps=3)
+
+    updated, _scheduled_days, _elapsed_days = service.apply_review(card, rating=1)
+    assert updated.state == CardState.RELEARNING
+    assert updated.next_review_at is not None
+    assert updated.last_review_at is not None
+    assert updated.next_review_at == updated.last_review_at + AGAIN_RETRY_DELAY
+
+    updated, _scheduled_days, _elapsed_days = service.apply_review(updated, rating=3)
+
+    assert updated.state == CardState.REVIEW
+    assert updated.next_review_at is not None
+    assert updated.last_review_at is not None
+    assert updated.next_review_at - updated.last_review_at >= timedelta(days=1)

--- a/frontend/src/app/(dashboard)/session/page.tsx
+++ b/frontend/src/app/(dashboard)/session/page.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { cardsApi, type Card } from "@/lib/api/cards";
 import { decksApi, type Deck } from "@/lib/api/decks";
 import { getSessionProgress } from "./session-progress";
+import { advanceQueue, shouldRequeue, type Rating } from "./session-queue";
 
 const ratingButtons = [
   { label: "Again", rating: 1, shortcut: "1", description: "Retry soon", tone: "bad" as const },
@@ -38,25 +39,29 @@ export default function SessionPage() {
   const searchParams = useSearchParams();
   const deckId = parseDeckId(searchParams.get("deck_id"));
 
-  const [cards, setCards] = useState<Card[]>([]);
+  // Cards are held in an explicit ordered queue; the head (index 0) is shown.
+  // A failed card is requeued behind the head, so the queue can outlive a
+  // single pass over the loaded cards (see session-queue.ts).
+  const [queue, setQueue] = useState<Card[]>([]);
   const [decks, setDecks] = useState<Deck[]>([]);
-  const [currentIndex, setCurrentIndex] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [sessionTotal, setSessionTotal] = useState(0);
-  const [reviewedCount, setReviewedCount] = useState(0);
+  // Distinct cards passed out of the session. Requeued cards are not counted
+  // until they finally get a passing rating, so progress never overflows.
+  const [completedCount, setCompletedCount] = useState(0);
   const [startedAt, setStartedAt] = useState<number>(() => Date.now());
   const isSubmittingRef = useRef(false);
 
-  const currentCard = cards[currentIndex];
+  const currentCard = queue[0];
   const deckById = useMemo(() => new Map(decks.map((deck) => [deck.id, deck])), [decks]);
   const currentDeck = currentCard?.deck_id ? deckById.get(currentCard.deck_id) : undefined;
   const { cardNumber, totalCards, progressPercent, estimatedMinutes } = getSessionProgress({
     sessionTotal,
-    reviewedCount,
+    reviewedCount: completedCount,
     hasCurrentCard: Boolean(currentCard),
   });
 
@@ -64,9 +69,8 @@ export default function SessionPage() {
     setLoading(true);
     setError(null);
     setIsFlipped(false);
-    setCurrentIndex(0);
     setSessionTotal(0);
-    setReviewedCount(0);
+    setCompletedCount(0);
     setIsSubmitting(false);
     isSubmittingRef.current = false;
 
@@ -75,7 +79,7 @@ export default function SessionPage() {
         cardsApi.getDueCards({ deck_id: deckId, limit: 100 }),
         decksApi.listDecks(),
       ]);
-      setCards(dueCards);
+      setQueue(dueCards);
       setDecks(allDecks);
       setSessionTotal(dueCards.length);
       setStartedAt(Date.now());
@@ -99,21 +103,25 @@ export default function SessionPage() {
   }, [currentCard, isAnimating, isSubmitting]);
 
   const handleRate = useCallback(
-    async (rating: 1 | 2 | 3 | 4) => {
+    async (rating: Rating) => {
       if (!currentCard || isSubmittingRef.current) return;
 
       isSubmittingRef.current = true;
       setIsSubmitting(true);
       setError(null);
       try {
+        // Exactly one review is recorded per rating, even for requeued cards.
         await cardsApi.reviewCard(currentCard.id, {
           rating,
           review_duration_ms: Date.now() - startedAt,
         });
 
-        setCards((existingCards) => existingCards.filter((card) => card.id !== currentCard.id));
-        setCurrentIndex(0);
-        setReviewedCount((count) => Math.min(count + 1, sessionTotal));
+        // Passing ratings drop the card and advance progress; a failed card is
+        // reinserted later in the queue and does not count as completed yet.
+        setQueue((existingQueue) => advanceQueue(existingQueue, rating));
+        if (!shouldRequeue(rating)) {
+          setCompletedCount((count) => Math.min(count + 1, sessionTotal));
+        }
         setIsFlipped(false);
         setStartedAt(Date.now());
       } catch (err) {

--- a/frontend/src/app/(dashboard)/session/session-queue.ts
+++ b/frontend/src/app/(dashboard)/session/session-queue.ts
@@ -1,0 +1,61 @@
+/**
+ * Study-session queue helpers.
+ *
+ * The session keeps an explicit ordered queue of cards in memory. The card at
+ * the head of the queue (index 0) is the one currently shown. Rating a card
+ * either removes it from the session (a passing rating) or requeues it later in
+ * the same session so the user gets another attempt before the session ends.
+ *
+ * These helpers are pure so they can be unit-tested without a DOM environment.
+ */
+
+export type Rating = 1 | 2 | 3 | 4;
+
+/**
+ * Ratings that requeue a card within the active session.
+ *
+ * Defaults to Again (1) only. Hard (2) is intentionally excluded: requeuing a
+ * card the user got right (just slowly) feels punishing and bloats the session.
+ * Add ratings here to change the default; the rest of the queue logic adapts.
+ */
+export const REQUEUE_RATINGS: readonly Rating[] = [1];
+
+/**
+ * How many cards to skip before a requeued card reappears. The card is
+ * reinserted this many positions behind the head, or at the end of the queue
+ * if fewer cards remain.
+ */
+export const REQUEUE_GAP = 3;
+
+/** Whether a rating causes the current card to reappear later this session. */
+export function shouldRequeue(rating: Rating): boolean {
+  return REQUEUE_RATINGS.includes(rating);
+}
+
+/**
+ * Apply a rating to the head card of an ordered session queue and return the
+ * next queue.
+ *
+ * - A passing rating removes the head card from the session.
+ * - A requeue rating (see {@link REQUEUE_RATINGS}) reinserts the head card
+ *   `gap` positions back, or at the end of the queue when fewer cards remain,
+ *   so it is seen again before the session finishes.
+ *
+ * The input queue is not mutated.
+ */
+export function advanceQueue<T>(
+  queue: readonly T[],
+  rating: Rating,
+  gap: number = REQUEUE_GAP,
+): T[] {
+  if (queue.length === 0) return [];
+
+  const [head, ...rest] = queue;
+
+  if (!shouldRequeue(rating)) {
+    return rest;
+  }
+
+  const insertAt = Math.min(Math.max(0, gap), rest.length);
+  return [...rest.slice(0, insertAt), head, ...rest.slice(insertAt)];
+}

--- a/frontend/src/app/(dashboard)/session/session.test.ts
+++ b/frontend/src/app/(dashboard)/session/session.test.ts
@@ -12,6 +12,7 @@
  *   - Empty due-cards list (the "All caught up" state)
  *   - reviewCard sends all four rating values (1-4) plus review_duration_ms
  *   - reviewCard failure surfaces a meaningful error message
+ *   - the in-session queue requeues failed cards and tracks progress correctly
  *
  * What is NOT covered here (requires a DOM/React render environment):
  *   - Rating buttons are visible only after the card is flipped
@@ -28,6 +29,12 @@ import {
   type NextStatesResponse,
 } from "@/lib/api/cards";
 import { getSessionProgress } from "./session-progress";
+import {
+  advanceQueue,
+  shouldRequeue,
+  REQUEUE_RATINGS,
+  REQUEUE_GAP,
+} from "./session-queue";
 import {
   installFetchMock,
   installWindowMock,
@@ -174,5 +181,77 @@ describe("session — rating a card", () => {
     await expect(
       cardsApi.reviewCard(999, { rating: 1, review_duration_ms: 1000 }),
     ).rejects.toThrow("Card not found");
+  });
+});
+
+describe("session — in-session requeue", () => {
+  test("Again is the only requeue rating by default", () => {
+    expect(REQUEUE_RATINGS).toEqual([1]);
+    expect(shouldRequeue(1)).toBe(true);
+    expect(shouldRequeue(2)).toBe(false);
+    expect(shouldRequeue(3)).toBe(false);
+    expect(shouldRequeue(4)).toBe(false);
+  });
+
+  test.each([2, 3, 4] as const)(
+    "a passing rating (%i) removes the head card from the queue",
+    (rating) => {
+      expect(advanceQueue(["a", "b", "c"], rating)).toEqual(["b", "c"]);
+    },
+  );
+
+  test("Again reinserts the failed card behind the requeue gap", () => {
+    // Gap of 1 so the reinserted position is easy to assert.
+    expect(advanceQueue(["a", "b", "c", "d"], 1, 1)).toEqual(["b", "a", "c", "d"]);
+  });
+
+  test("Again uses the default gap of 3 when not overridden", () => {
+    const queue = ["a", "b", "c", "d", "e"];
+    expect(REQUEUE_GAP).toBe(3);
+    expect(advanceQueue(queue, 1)).toEqual(["b", "c", "d", "a", "e"]);
+  });
+
+  test("a failed card is appended at the end when fewer cards than the gap remain", () => {
+    expect(advanceQueue(["a", "b"], 1, 3)).toEqual(["b", "a"]);
+  });
+
+  test("the only remaining card keeps being shown until it is passed", () => {
+    expect(advanceQueue(["a"], 1)).toEqual(["a"]);
+    expect(advanceQueue(["a"], 3)).toEqual([]);
+  });
+
+  test("does not mutate the input queue", () => {
+    const queue = ["a", "b", "c"];
+    advanceQueue(queue, 1, 1);
+    expect(queue).toEqual(["a", "b", "c"]);
+  });
+
+  test("progress counts distinct passed cards and never overflows when cards requeue", () => {
+    // Session of 2 cards. Card A is failed once (requeued), then both pass.
+    // Completed count must reach exactly the session total, never exceed it.
+    const total = 2;
+    let queue = ["a", "b"];
+    let completed = 0;
+
+    const rate = (rating: 1 | 2 | 3 | 4) => {
+      queue = advanceQueue(queue, rating);
+      if (!shouldRequeue(rating)) completed = Math.min(completed + 1, total);
+    };
+
+    rate(1); // A failed → requeued, not counted
+    expect(completed).toBe(0);
+    expect(queue).toEqual(["b", "a"]);
+
+    rate(3); // B passed
+    rate(3); // A passed
+    expect(completed).toBe(2);
+    expect(queue).toEqual([]);
+
+    expect(getSessionProgress({ sessionTotal: total, reviewedCount: completed, hasCurrentCard: false })).toMatchObject({
+      cardNumber: 2,
+      totalCards: 2,
+      progressPercent: 100,
+      remaining: 0,
+    });
   });
 });


### PR DESCRIPTION
Closes #87

## Problem / root cause

During a study session, cards the user fails are not given another chance before the session ends. Review intervals were effectively day-based (at least one day), so a failed card was not due again the same day after a refresh/exit, and the frontend session also walked cards with an always-index-0 + `filter` pattern that had no room to reinsert a card mid-queue. Progress was driven by raw review count clamped to a total frozen at load.

## Key changes

- **Explicit ordered queue.** Session cards now live in an ordered `queue` where the head (index 0) is the current card, replacing the always-index-0 + filter pattern.
- **In-session requeue.** Rating **Again** reinserts the card a few positions back (or at the end if fewer cards remain) so it reappears before the session ends; passing ratings remove it. Logic lives in a pure, tested `session-queue.ts` helper.
- **Durable same-day retry.** Rating **Again** now persists `next_review_at` as immediately due, so `/cards/due` can surface the failed card again today after refreshes, exits, crashes, or timeouts. Passing ratings keep the existing day-based scheduling path.
- **Hard does not requeue by default.** Requeue ratings sit behind a single `REQUEUE_RATINGS` constant defaulting to `[1]` (Again), so enabling Hard later is a one-line change.
- **Correct progress.** Progress now counts distinct *passed* cards, so a requeued card no longer freezes or overflows the `nn / nn` counter.
- **Unchanged review logging invariant.** Exactly one `POST /cards/{id}/review` is sent per rating attempt; repeated attempts for requeued cards are logged as normal reviews.

## Test plan

- Added frontend unit tests in `session.test.ts` covering: Again as the only default requeue rating, passing ratings dropping the head, reinsert gap behavior (default and override), end-of-queue fallback, single-card looping, input immutability, and progress counting without overflow.
- Added backend unit tests in `test_fsrs_service.py` covering: Again persists an immediate same-day retry, passing ratings keep day-based scheduling, and passing after Again graduates the card out of immediate retry.
- Backend targeted: `uv run --project backend --extra dev pytest backend/tests/test_fsrs_service.py -q` → 3 pass / 0 fail.
- Backend suite: `PYTHONPATH=/home/spark/projects/glot/backend uv run --project backend --extra dev pytest backend/tests -q` with test env overrides → 23 pass / 0 fail.
- Frontend: `bun test` → 98 pass / 0 fail.
- ESLint on changed frontend files: clean.
- Backend Ruff on changed backend files: clean.
- `bun --bun next build`: successful; existing CSS `@import` ordering warning remains unrelated.

## Impact / risk

Small frontend/backend scheduling change. Backend review logging and API shape are unchanged; the durable part only changes the timestamp persisted for **Again** reviews so failed cards stay due today. No schema, migration, Docker, infra, or deployment changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)