### PR TITLE
feat: randomize and stabilize review queue ordering

### DIFF
--- a/backend/app/api/v1/cards.py
+++ b/backend/app/api/v1/cards.py
@@ -17,8 +17,8 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from loguru import logger
+from sqlalchemy import case, func
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import func
 from sqlmodel import select
 
 from app.core import get_settings
@@ -37,6 +37,7 @@ from app.schemas import (
 )
 from app.schemas.card import ReviewRequest, ReviewResponse
 from app.services import FSRSService
+from app.services.review_queue import order_due_cards
 
 router = APIRouter()
 
@@ -153,12 +154,23 @@ async def get_due_cards(
     current_user: Annotated[User, Depends(get_current_user)],
     limit: int = Query(20, ge=1, le=100),
     deck_id: int | None = None,
+    seed: int | None = Query(
+        None,
+        description="Optional RNG seed for a stable queue order across requests. "
+        "Omit to randomise the order on every request.",
+    ),
 ):
     """
     Get cards due for review.
 
     Returns cards where next_review_at <= now, plus new cards.
-    Ordered by: overdue cards first (oldest), then new cards.
+
+    Selection (which cards fit within `limit`) is priority-based:
+    learning/relearning first, then most-overdue reviews, then new cards.
+
+    Presentation order is non-sequential: learning/relearning come first, then
+    review and new cards are shuffled and interleaved so the queue does not
+    follow a fixed deterministic order. Pass `seed` for a stable order.
     """
     if deck_id is not None:
         deck = await _get_owned_deck(session, deck_id, current_user.id)
@@ -179,11 +191,22 @@ async def get_due_cards(
     if deck_id:
         query = query.where(Card.deck_id == deck_id)
 
-    # Order: overdue first (most overdue at top), then new
-    query = query.order_by(Card.next_review_at.asc().nullsfirst()).limit(limit)
+    # Priority for which cards make the `limit` cut: learning/relearning first,
+    # then due reviews, then new. Within a tier, most-overdue first so we never
+    # randomly drop overdue cards. Presentation order is randomised afterwards.
+    priority = case(
+        (Card.state.in_((CardState.LEARNING, CardState.RELEARNING)), 0),
+        (Card.state == CardState.REVIEW, 1),
+        else_=2,
+    )
+    query = query.order_by(
+        priority.asc(), Card.next_review_at.asc().nullsfirst()
+    ).limit(limit)
 
     result = await session.execute(query)
-    return result.scalars().all()
+    due_cards = result.scalars().all()
+
+    return order_due_cards(due_cards, seed=seed)
 
 
 @router.get("/{card_id}", response_model=CardRead)

--- a/backend/app/services/review_queue.py
+++ b/backend/app/services/review_queue.py
@@ -1,0 +1,83 @@
+"""
+Review-queue ordering for the study session.
+
+The ``/cards/due`` endpoint selects which cards are due (respecting priority and
+the result limit), then uses these helpers to decide the *presentation order* so
+the queue does not feel sequential or predictable.
+
+Ordering policy:
+    1. Learning / relearning cards come first (highest priority), shuffled.
+    2. Due review cards and new cards are interleaved together, each shuffled,
+       so new cards are spread among reviews rather than front- or back-loaded.
+
+Randomisation uses a per-request RNG. Passing a ``seed`` makes the order stable
+across requests (useful for a stable session), while omitting it randomises the
+order on every request.
+
+These functions are pure (no DB/ORM access) so they are easy to unit-test.
+"""
+
+import random
+from collections.abc import Sequence
+
+from app.models.card import CardState
+
+# Cards mid-learning or being relearned after a lapse are the most fragile, so
+# they are surfaced first.
+LEARNING_STATES = frozenset({CardState.LEARNING, CardState.RELEARNING})
+
+
+def interleave[T](primary: Sequence[T], secondary: Sequence[T]) -> list[T]:
+    """Evenly interleave ``secondary`` items among ``primary`` items.
+
+    Secondary items are spread across the full span of primary items so they are
+    neither clustered at the front nor at the back. The relative order within
+    each input sequence is preserved.
+    """
+    if not secondary:
+        return list(primary)
+    if not primary:
+        return list(secondary)
+
+    total = len(primary) + len(secondary)
+    n_secondary = len(secondary)
+    result: list[T] = []
+    pi = si = 0
+
+    for k in range(total):
+        # How many secondary items "should" have been emitted by this position
+        # if they were spread perfectly evenly.
+        target_secondary = round((k + 1) * n_secondary / total)
+        take_secondary = si < n_secondary and (si < target_secondary or pi >= len(primary))
+        if take_secondary:
+            result.append(secondary[si])
+            si += 1
+        else:
+            result.append(primary[pi])
+            pi += 1
+
+    return result
+
+
+def order_due_cards[T](cards: Sequence[T], seed: int | None = None) -> list[T]:
+    """Return due ``cards`` in presentation order.
+
+    Learning/relearning cards come first (shuffled); due review and new cards are
+    shuffled and interleaved so new cards are sprinkled among the reviews.
+
+    Each card must expose a ``state`` attribute (:class:`CardState`). The input
+    is not mutated.
+    """
+    rng = random.Random(seed)
+
+    learning = [c for c in cards if c.state in LEARNING_STATES]
+    new = [c for c in cards if c.state == CardState.NEW]
+    # Everything else (i.e. due REVIEW cards) — defined as a catch-all so no
+    # card is ever dropped from the queue.
+    review = [c for c in cards if c.state not in LEARNING_STATES and c.state != CardState.NEW]
+
+    rng.shuffle(learning)
+    rng.shuffle(review)
+    rng.shuffle(new)
+
+    return learning + interleave(review, new)

--- a/backend/tests/test_review_queue.py
+++ b/backend/tests/test_review_queue.py
@@ -1,0 +1,143 @@
+"""Unit tests for review-queue ordering (app/services/review_queue.py).
+
+These cover the pure ordering helpers without a DB: bucket priority,
+new-card interleaving, non-fixed ordering, and seed stability.
+"""
+
+from dataclasses import dataclass
+
+from app.models.card import CardState
+from app.services.review_queue import interleave, order_due_cards
+
+
+@dataclass
+class FakeCard:
+    """Minimal stand-in: order_due_cards only reads ``state`` (and we add an id
+    so test assertions can compare ordering)."""
+
+    id: int
+    state: CardState
+
+
+def _ids(cards):
+    return [c.id for c in cards]
+
+
+def _make(n, state, start=0):
+    return [FakeCard(id=start + i, state=state) for i in range(n)]
+
+
+# --------------------------------------------------------------------------- #
+# interleave
+# --------------------------------------------------------------------------- #
+
+
+def test_interleave_empty_secondary_returns_primary_copy():
+    primary = [1, 2, 3]
+    result = interleave(primary, [])
+    assert result == [1, 2, 3]
+    assert result is not primary  # a copy, not the original list
+
+
+def test_interleave_empty_primary_returns_secondary_copy():
+    assert interleave([], ["a", "b"]) == ["a", "b"]
+
+
+def test_interleave_spreads_secondary_without_front_or_back_loading():
+    primary = [f"r{i}" for i in range(8)]
+    secondary = ["n0", "n1"]
+
+    result = interleave(primary, secondary)
+
+    # No cards lost or duplicated.
+    assert sorted(result) == sorted(primary + secondary)
+    positions = [result.index(s) for s in secondary]
+    # Not all secondary clustered at the very front...
+    assert not all(p < len(secondary) for p in positions)
+    # ...nor at the very back.
+    assert not all(p >= len(primary) for p in positions)
+    # Relative order within each input is preserved.
+    assert result.index("n0") < result.index("n1")
+
+
+# --------------------------------------------------------------------------- #
+# order_due_cards — bucket priority
+# --------------------------------------------------------------------------- #
+
+
+def test_learning_and_relearning_come_before_review_and_new():
+    cards = (
+        _make(2, CardState.REVIEW, start=0)
+        + _make(2, CardState.NEW, start=10)
+        + _make(1, CardState.LEARNING, start=20)
+        + _make(1, CardState.RELEARNING, start=30)
+    )
+
+    result = order_due_cards(cards, seed=7)
+
+    learning_states = {CardState.LEARNING, CardState.RELEARNING}
+    state_by_id = {c.id: c.state for c in cards}
+    ordered_states = [state_by_id[i] for i in _ids(result)]
+    last_learning = max(
+        i for i, s in enumerate(ordered_states) if s in learning_states
+    )
+    first_other = min(
+        i for i, s in enumerate(ordered_states) if s not in learning_states
+    )
+    assert last_learning < first_other
+
+
+def test_new_cards_interleaved_among_reviews_not_back_loaded():
+    cards = _make(8, CardState.REVIEW, start=0) + _make(2, CardState.NEW, start=100)
+
+    result = order_due_cards(cards, seed=3)
+    new_ids = {c.id for c in cards if c.state == CardState.NEW}
+    positions = [i for i, c in enumerate(result) if c.id in new_ids]
+
+    # New cards must not all sit at the front or all at the back.
+    assert not all(p < len(new_ids) for p in positions)
+    assert not all(p >= len(cards) - len(new_ids) for p in positions)
+
+
+# --------------------------------------------------------------------------- #
+# order_due_cards — randomness and seed stability
+# --------------------------------------------------------------------------- #
+
+
+def test_same_seed_yields_stable_order():
+    cards = _make(12, CardState.REVIEW)
+    assert _ids(order_due_cards(cards, seed=42)) == _ids(order_due_cards(cards, seed=42))
+
+
+def test_different_seeds_change_the_order():
+    cards = _make(12, CardState.REVIEW)
+    orders = {tuple(_ids(order_due_cards(cards, seed=s))) for s in range(8)}
+    # With 12 cards, distinct seeds should not all collapse to one order.
+    assert len(orders) > 1
+
+
+def test_omitting_seed_randomises_across_requests():
+    cards = _make(12, CardState.REVIEW)
+    orders = {tuple(_ids(order_due_cards(cards))) for _ in range(10)}
+    assert len(orders) > 1
+
+
+def test_ordering_preserves_all_cards_without_loss_or_duplication():
+    cards = (
+        _make(5, CardState.REVIEW, start=0)
+        + _make(3, CardState.NEW, start=100)
+        + _make(2, CardState.LEARNING, start=200)
+    )
+    result = order_due_cards(cards, seed=1)
+    assert sorted(_ids(result)) == sorted(_ids(cards))
+
+
+def test_does_not_mutate_input():
+    cards = _make(6, CardState.REVIEW)
+    before = _ids(cards)
+    order_due_cards(cards, seed=1)
+    assert _ids(cards) == before
+
+
+def test_empty_input_returns_empty_list():
+    assert order_due_cards([]) == []

--- a/frontend/src/app/(dashboard)/session/page.tsx
+++ b/frontend/src/app/(dashboard)/session/page.tsx
@@ -9,6 +9,7 @@ import { cardsApi, type Card } from "@/lib/api/cards";
 import { decksApi, type Deck } from "@/lib/api/decks";
 import { getSessionProgress } from "./session-progress";
 import { advanceQueue, shouldRequeue, type Rating } from "./session-queue";
+import { clearSessionSeed, getOrCreateSessionSeed } from "./session-seed";
 
 const ratingButtons = [
   { label: "Again", rating: 1, shortcut: "1", description: "Retry soon", tone: "bad" as const },
@@ -75,8 +76,12 @@ export default function SessionPage() {
     isSubmittingRef.current = false;
 
     try {
+      // Reuse a stable per-session seed so an interrupted session (reload, tab
+      // close) resumes in the same order rather than reshuffling. Scoped per
+      // deck (and mixed review) so switching scopes gets its own order.
+      const seed = getOrCreateSessionSeed(window.localStorage, deckId);
       const [dueCards, allDecks] = await Promise.all([
-        cardsApi.getDueCards({ deck_id: deckId, limit: 100 }),
+        cardsApi.getDueCards({ deck_id: deckId, limit: 100, seed }),
         decksApi.listDecks(),
       ]);
       setQueue(dueCards);
@@ -93,6 +98,17 @@ export default function SessionPage() {
   useEffect(() => {
     void loadSession();
   }, [loadSession]);
+
+  useEffect(() => {
+    // Once the loaded cards are all worked through, the logical session is over,
+    // so drop the seed and let the next session pick a fresh order. Guard on
+    // loading/error: a transient empty queue during a (re)load or after a failed
+    // fetch must not clear a seed an in-progress session still needs.
+    if (loading || error) return;
+    if (queue.length === 0) {
+      clearSessionSeed(window.localStorage, deckId);
+    }
+  }, [loading, error, queue.length, deckId]);
 
   const handleFlip = useCallback(() => {
     if (!currentCard || isAnimating || isSubmitting) return;

--- a/frontend/src/app/(dashboard)/session/session-seed.ts
+++ b/frontend/src/app/(dashboard)/session/session-seed.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-logical-session RNG seed for stable due-card ordering.
+ *
+ * The `/cards/due` endpoint accepts an optional `seed` that fixes the
+ * presentation order: with the same selected due-card set, the same seed yields
+ * the same order. We generate a seed once per logical session and persist it in
+ * browser storage, so an interruption (reload, tab close, navigation) resumes
+ * the session in the same order instead of reshuffling.
+ *
+ * The seed is scoped: a deck-specific session and a mixed-review session must
+ * not share a seed, otherwise switching scopes would reuse a stale order.
+ *
+ * These helpers are pure (storage and the RNG are injectable) so they can be
+ * unit-tested without a DOM environment, matching the other session helpers.
+ */
+
+/** The subset of the Web Storage API the seed helpers use. Browser storage
+ * (`window.localStorage` in production) and a test fake satisfy it. */
+export type SeedStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+const SEED_KEY_PREFIX = "glot:session-seed:";
+
+/**
+ * Largest seed we generate: 2^31 - 1. This stays a safe JS integer (well under
+ * `Number.MAX_SAFE_INTEGER`) and within a signed 32-bit range, so it survives
+ * the round-trip to the backend `int` unchanged regardless of how it is stored.
+ */
+export const MAX_SEED = 0x7fffffff;
+
+/**
+ * Browser-storage key for a session scope. `deckId` identifies a deck-specific
+ * session; `undefined` is the mixed-review session. Keeping the scope in the key
+ * is what stops the two from sharing a seed.
+ */
+export function sessionSeedKey(deckId: number | undefined): string {
+  return `${SEED_KEY_PREFIX}${deckId ?? "mixed"}`;
+}
+
+/**
+ * A browser-safe random seed in `[0, MAX_SEED]`.
+ *
+ * Uses the Web Crypto RNG; masking off the high bit maps any 32-bit value into
+ * the signed range without modulo bias.
+ */
+export function randomSeed(): number {
+  const buf = new Uint32Array(1);
+  crypto.getRandomValues(buf);
+  return buf[0] & MAX_SEED;
+}
+
+/**
+ * Return the persisted seed for this scope, or create, store, and return a new
+ * one. Reusing the stored seed across reloads is what keeps an interrupted
+ * session's order stable; a missing or corrupt value is replaced.
+ */
+export function getOrCreateSessionSeed(
+  storage: SeedStorage,
+  deckId: number | undefined,
+  generate: () => number = randomSeed,
+): number {
+  const key = sessionSeedKey(deckId);
+  const stored = storage.getItem(key);
+  if (stored !== null) {
+    const parsed = Number(stored);
+    if (Number.isInteger(parsed) && parsed >= 0 && parsed <= MAX_SEED) return parsed;
+  }
+
+  const seed = generate();
+  storage.setItem(key, String(seed));
+  return seed;
+}
+
+/**
+ * Drop the stored seed for this scope so the next session in the same scope
+ * starts from a fresh order. Call this only when the session genuinely finishes.
+ */
+export function clearSessionSeed(storage: SeedStorage, deckId: number | undefined): void {
+  storage.removeItem(sessionSeedKey(deckId));
+}

--- a/frontend/src/app/(dashboard)/session/session.test.ts
+++ b/frontend/src/app/(dashboard)/session/session.test.ts
@@ -13,6 +13,7 @@
  *   - reviewCard sends all four rating values (1-4) plus review_duration_ms
  *   - reviewCard failure surfaces a meaningful error message
  *   - the in-session queue requeues failed cards and tracks progress correctly
+ *   - the per-session seed is scoped, persisted, reused, and cleared correctly
  *
  * What is NOT covered here (requires a DOM/React render environment):
  *   - Rating buttons are visible only after the card is flipped
@@ -35,6 +36,14 @@ import {
   REQUEUE_RATINGS,
   REQUEUE_GAP,
 } from "./session-queue";
+import {
+  clearSessionSeed,
+  getOrCreateSessionSeed,
+  MAX_SEED,
+  randomSeed,
+  sessionSeedKey,
+  type SeedStorage,
+} from "./session-seed";
 import {
   installFetchMock,
   installWindowMock,
@@ -253,5 +262,102 @@ describe("session — in-session requeue", () => {
       progressPercent: 100,
       remaining: 0,
     });
+  });
+});
+
+/** In-memory `SeedStorage` standing in for browser storage. */
+function makeStorage(initial: Record<string, string> = {}): SeedStorage & {
+  store: Map<string, string>;
+} {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => void store.set(key, value),
+    removeItem: (key) => void store.delete(key),
+  };
+}
+
+describe("session — per-session seed", () => {
+  test("scopes the storage key per deck, and apart from mixed review", () => {
+    const mixed = sessionSeedKey(undefined);
+    const deck1 = sessionSeedKey(1);
+    const deck2 = sessionSeedKey(2);
+
+    expect(new Set([mixed, deck1, deck2]).size).toBe(3);
+    // Stable across calls so reload reads back the same slot.
+    expect(sessionSeedKey(1)).toBe(deck1);
+  });
+
+  test("randomSeed stays a non-negative integer within seed bounds", () => {
+    expect(MAX_SEED).toBe(0x7fffffff);
+    for (let i = 0; i < 1000; i += 1) {
+      const seed = randomSeed();
+      expect(Number.isInteger(seed)).toBe(true);
+      expect(seed).toBeGreaterThanOrEqual(0);
+      expect(seed).toBeLessThanOrEqual(MAX_SEED);
+    }
+  });
+
+  test("creates and persists a fresh seed when none is stored", () => {
+    const storage = makeStorage();
+
+    const seed = getOrCreateSessionSeed(storage, 7, () => 42);
+
+    expect(seed).toBe(42);
+    expect(storage.getItem(sessionSeedKey(7))).toBe("42");
+  });
+
+  test("reuses the stored seed across calls (interruption-friendly)", () => {
+    const storage = makeStorage();
+    const generate = () => Math.floor(Math.random() * MAX_SEED);
+
+    const first = getOrCreateSessionSeed(storage, 7, generate);
+    const second = getOrCreateSessionSeed(storage, 7, generate);
+
+    expect(second).toBe(first);
+  });
+
+  test("deck and mixed sessions keep independent seeds", () => {
+    const storage = makeStorage();
+
+    const deckSeed = getOrCreateSessionSeed(storage, 7, () => 11);
+    const mixedSeed = getOrCreateSessionSeed(storage, undefined, () => 22);
+
+    expect(deckSeed).toBe(11);
+    expect(mixedSeed).toBe(22);
+  });
+
+  test("regenerates when the stored value is corrupt", () => {
+    const storage = makeStorage({ [sessionSeedKey(7)]: "not-a-number" });
+
+    const seed = getOrCreateSessionSeed(storage, 7, () => 99);
+
+    expect(seed).toBe(99);
+    expect(storage.getItem(sessionSeedKey(7))).toBe("99");
+  });
+
+  test("regenerates when the stored value is outside backend seed bounds", () => {
+    const storage = makeStorage({ [sessionSeedKey(7)]: String(MAX_SEED + 1) });
+
+    const seed = getOrCreateSessionSeed(storage, 7, () => 123);
+
+    expect(seed).toBe(123);
+    expect(storage.getItem(sessionSeedKey(7))).toBe("123");
+  });
+
+  test("clearing drops only the matching scope's seed", () => {
+    const storage = makeStorage();
+    getOrCreateSessionSeed(storage, 7, () => 11);
+    getOrCreateSessionSeed(storage, undefined, () => 22);
+
+    clearSessionSeed(storage, 7);
+
+    expect(storage.getItem(sessionSeedKey(7))).toBeNull();
+    expect(storage.getItem(sessionSeedKey(undefined))).toBe("22");
+
+    // After clearing, the next session draws a fresh seed.
+    const fresh = getOrCreateSessionSeed(storage, 7, () => 33);
+    expect(fresh).toBe(33);
   });
 });

--- a/frontend/src/lib/api/cards.test.ts
+++ b/frontend/src/lib/api/cards.test.ts
@@ -154,6 +154,33 @@ describe("cardsApi.getDueCards", () => {
       "/api/v1/cards/due?deck_id=3&limit=5",
     );
   });
+
+  test("includes seed when provided", async () => {
+    fetchMock.enqueue(() => jsonResponse([]));
+
+    await cardsApi.getDueCards({ deck_id: 3, limit: 5, seed: 12345 });
+
+    const url = new URL(fetchMock.calls[0].url, "http://localhost");
+    expect(url.searchParams.get("seed")).toBe("12345");
+  });
+
+  test("sends seed 0 (a valid seed, not omitted as falsy)", async () => {
+    fetchMock.enqueue(() => jsonResponse([]));
+
+    await cardsApi.getDueCards({ seed: 0 });
+
+    const url = new URL(fetchMock.calls[0].url, "http://localhost");
+    expect(url.searchParams.get("seed")).toBe("0");
+  });
+
+  test("omits seed when not provided", async () => {
+    fetchMock.enqueue(() => jsonResponse([]));
+
+    await cardsApi.getDueCards({ deck_id: 3, limit: 5 });
+
+    const url = new URL(fetchMock.calls[0].url, "http://localhost");
+    expect(url.searchParams.has("seed")).toBe(false);
+  });
 });
 
 describe("cardsApi.updateCard", () => {

--- a/frontend/src/lib/api/cards.ts
+++ b/frontend/src/lib/api/cards.ts
@@ -40,6 +40,13 @@ export interface CardListResponse {
 export interface DueCardsOptions {
   deck_id?: number;
   limit?: number;
+  /**
+   * Optional RNG seed for a stable presentation order across requests. With the
+   * same due-card set, the same seed yields the same order, so an interrupted
+   * study session (reload, tab close) resumes in the same order. Omit to let the
+   * backend randomise the order on every request.
+   */
+  seed?: number;
 }
 
 export interface CreateCardRequest {
@@ -223,6 +230,10 @@ class CardsApi {
       params.set("deck_id", String(options.deck_id));
     }
     params.set("limit", String(options.limit ?? 20));
+    // Send 0 too: it is a valid seed, so guard on `undefined`, not falsiness.
+    if (options.seed !== undefined) {
+      params.set("seed", String(options.seed));
+    }
 
     const query = params.toString();
     const response = await fetchWithAuth(`${API_BASE}/due${query ? `?${query}` : ""}`, {


### PR DESCRIPTION
Closes #86

## Problem / root cause

The due-card endpoint returned cards in strict `next_review_at` order, making study sessions feel sequential and predictable. New cards and reviews were not mixed into a varied presentation order.

Also, interrupted study sessions could reshuffle on reload/reopen because the frontend was not passing a stable queue seed back to the backend.

## Key changes

- **Priority-based selection.** `/cards/due` now selects cards by priority before applying `limit`: learning/relearning first, due reviews next, new cards last.
- **Randomized presentation.** Selected cards are passed through a pure `order_due_cards` helper that shuffles priority groups so order is not fixed across sessions.
- **New-card interleaving.** Review and new cards are interleaved after shuffling so new cards are spread among reviews instead of front- or back-loaded.
- **Optional stable seed.** `/cards/due?seed=...` gives stable queue ordering for the same selected set; omitting it randomizes each request.
- **Frontend session seed.** The study session generates a browser-safe per-scope seed, persists it in `localStorage`, and sends it to `/cards/due` so reload/tab-close interruptions keep the same order.
- **Scoped seed storage.** Mixed-review and deck-specific sessions use separate seed keys; the seed is cleared when the loaded session is genuinely completed.
- **Focused tests.** Added unit tests for backend queue priority/interleaving/seed stability and frontend seed query/persistence behavior.

## Test plan

- `PYTHONPATH=/home/spark/projects/glot/backend backend/.venv/bin/pytest backend/tests -q` → previously 34 pass / 0 fail before frontend follow-up.
- `backend/.venv/bin/ruff check backend/app/api/v1/cards.py backend/app/services/review_queue.py backend/tests/test_review_queue.py` → previously clean before frontend follow-up.
- `cd frontend && bun test` → 109 pass / 0 fail.
- `cd frontend && bun run lint` → 0 errors, 7 existing warnings in untouched files.
- `cd frontend && bun --bun next build` → successful; existing CSS `@import` ordering warning remains unrelated.
- `git diff --check` → clean.

## Impact / risk

Backend/frontend review-session ordering change only. Ownership, deck filtering, limit bounds, empty/all-caught-up behavior, and review submission semantics are preserved. No schema, migration, Docker, infra, or deployment changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)