### PR TITLE
feat(review): show optional language-learning fields on review cards

### DIFF
--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -17,6 +17,7 @@ from .auth import (
 from .card import (
     CardCreate,
     CardListResponse,
+    CardMetadata,
     CardRead,
     CardUpdate,
     NextStatesResponse,
@@ -52,6 +53,7 @@ __all__ = [
     "CardCreate",
     "CardRead",
     "CardListResponse",
+    "CardMetadata",
     "CardUpdate",
     "ReviewRequest",
     "ReviewResponse",

--- a/backend/app/schemas/card.py
+++ b/backend/app/schemas/card.py
@@ -5,9 +5,40 @@ Card schemas for API request/response validation.
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.models.card import CardState
+
+
+class CardMetadata(BaseModel):
+    """Recognized optional language-learning fields inside a card's ``meta_data``.
+
+    These live in the card's free-form ``meta_data`` JSONB (the established
+    "type-specific fields" plumbing), so they are entirely optional and never
+    required for existing cards. This model documents the recognized keys so the
+    review UI can receive and display them cleanly when provided.
+
+    ``extra="allow"`` preserves any other metadata keys already stored on a card
+    (e.g. vocab readings) so typing these fields never drops unrelated data.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    phonetics: str | None = Field(
+        default=None, description="Pronunciation / phonetic transcription (e.g. IPA)"
+    )
+    word_type: str | None = Field(
+        default=None, description="Part of speech, e.g. noun, verb, adjective, adverb"
+    )
+    gender: str | None = Field(
+        default=None, description="Grammatical gender, e.g. masculine, feminine, neuter"
+    )
+    example: str | None = Field(
+        default=None, description="Example sentence using the word/phrase"
+    )
+    example_translation: str | None = Field(
+        default=None, description="Translation of the example sentence"
+    )
 
 
 class CardCreate(BaseModel):
@@ -15,6 +46,9 @@ class CardCreate(BaseModel):
 
     front_content: str = Field(min_length=1, max_length=10000)
     back_content: str = Field(min_length=1, max_length=10000)
+    # Free-form metadata; optional language-learning fields (phonetics,
+    # word_type, gender, example, example_translation) are documented by
+    # CardMetadata and passed through when provided.
     meta_data: dict[str, Any] = Field(default_factory=dict)
     tags: list[str] = Field(default_factory=list)
     deck_id: int = Field(description="Deck this card belongs to")
@@ -38,6 +72,8 @@ class CardRead(BaseModel):
 
     front_content: str
     back_content: str
+    # See CardMetadata for the recognized optional language-learning keys the
+    # review UI displays (all optional; other keys are preserved as-is).
     meta_data: dict[str, Any]
     tags: list[str]
     deck_id: int | None

--- a/backend/app/schemas/card.py
+++ b/backend/app/schemas/card.py
@@ -39,6 +39,10 @@ class CardMetadata(BaseModel):
     example_translation: str | None = Field(
         default=None, description="Translation of the example sentence"
     )
+    example_highlight: str | None = Field(
+        default=None,
+        description="Substring of the example to emphasize (usually the target word)",
+    )
 
 
 class CardCreate(BaseModel):

--- a/backend/tests/test_card_metadata.py
+++ b/backend/tests/test_card_metadata.py
@@ -27,6 +27,7 @@ def test_metadata_accepts_language_fields():
             "gender": "masculine",
             "example": "Le chat dort.",
             "example_translation": "The cat sleeps.",
+            "example_highlight": "chat",
         }
     )
 
@@ -35,6 +36,7 @@ def test_metadata_accepts_language_fields():
     assert meta.gender == "masculine"
     assert meta.example == "Le chat dort."
     assert meta.example_translation == "The cat sleeps."
+    assert meta.example_highlight == "chat"
 
 
 def test_metadata_preserves_unrelated_keys():

--- a/backend/tests/test_card_metadata.py
+++ b/backend/tests/test_card_metadata.py
@@ -1,0 +1,90 @@
+"""Tests for the optional language-learning card metadata contract.
+
+These fields live in the card's free-form ``meta_data`` JSONB, so they must be
+fully optional, never required for existing cards, and pass through untouched
+when provided. ``CardMetadata`` documents the recognized keys for the review UI.
+"""
+
+from app.schemas import CardCreate, CardMetadata, CardRead
+
+
+def test_metadata_fields_are_all_optional():
+    """An empty metadata object is valid and yields all-None known fields."""
+    meta = CardMetadata()
+
+    assert meta.phonetics is None
+    assert meta.word_type is None
+    assert meta.gender is None
+    assert meta.example is None
+    assert meta.example_translation is None
+
+
+def test_metadata_accepts_language_fields():
+    meta = CardMetadata.model_validate(
+        {
+            "phonetics": "/ʃa/",
+            "word_type": "noun",
+            "gender": "masculine",
+            "example": "Le chat dort.",
+            "example_translation": "The cat sleeps.",
+        }
+    )
+
+    assert meta.phonetics == "/ʃa/"
+    assert meta.word_type == "noun"
+    assert meta.gender == "masculine"
+    assert meta.example == "Le chat dort."
+    assert meta.example_translation == "The cat sleeps."
+
+
+def test_metadata_preserves_unrelated_keys():
+    """Unrelated existing metadata (e.g. vocab readings) is never dropped."""
+    meta = CardMetadata.model_validate({"reading": "ねこ", "word_type": "noun"})
+
+    dumped = meta.model_dump()
+    assert dumped["reading"] == "ねこ"
+    assert dumped["word_type"] == "noun"
+
+
+def test_card_create_passes_language_metadata_through():
+    """The create schema carries the language fields through meta_data verbatim."""
+    payload = {
+        "front_content": "chat",
+        "back_content": "cat",
+        "deck_id": 1,
+        "meta_data": {
+            "phonetics": "/ʃa/",
+            "word_type": "noun",
+            "gender": "masculine",
+        },
+    }
+
+    card = CardCreate.model_validate(payload)
+
+    assert card.meta_data == payload["meta_data"]
+
+
+def test_card_read_keeps_metadata_without_requiring_language_fields():
+    """A legacy card with unrelated metadata reads back unchanged."""
+    card = CardRead.model_validate(
+        {
+            "id": 1,
+            "sequence": 1,
+            "front_content": "chat",
+            "back_content": "cat",
+            "meta_data": {"reading": "x"},
+            "tags": [],
+            "deck_id": 1,
+            "difficulty": 5.0,
+            "stability": 0.0,
+            "state": "new",
+            "reps": 0,
+            "lapses": 0,
+            "last_review_at": None,
+            "next_review_at": None,
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+        }
+    )
+
+    assert card.meta_data == {"reading": "x"}

--- a/frontend/src/app/(dashboard)/session/card-meta-details.tsx
+++ b/frontend/src/app/(dashboard)/session/card-meta-details.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+/**
+ * Review-only display of a card's optional language-learning metadata.
+ *
+ * Rendered on the answer face of the review card. Each field is independently
+ * optional: a chip/section only appears when its value is present, so a card
+ * without metadata renders nothing and the review flow is unchanged.
+ */
+
+import { Icon } from "@/components/glot/icon";
+import { hasCardMeta, type CardMeta } from "@/lib/cards/meta";
+
+function MetaChip({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <span
+      className="pill outline"
+      style={{ display: "inline-flex", gap: 6, alignItems: "baseline" }}
+    >
+      <span
+        className="mono"
+        style={{ fontSize: 9, letterSpacing: "0.12em", color: "var(--muted-2)", textTransform: "uppercase" }}
+      >
+        {label}
+      </span>
+      <span className={mono ? "mono" : undefined} style={{ color: "var(--fg)" }}>
+        {value}
+      </span>
+    </span>
+  );
+}
+
+export function CardMetaDetails({ meta }: { meta: CardMeta }) {
+  if (!hasCardMeta(meta)) return null;
+
+  const hasChips = Boolean(meta.wordType || meta.gender || meta.phonetics);
+  const hasExample = Boolean(meta.example || meta.exampleTranslation);
+
+  return (
+    <div
+      className="w-full max-w-xl mt-6 pt-5"
+      style={{ borderTop: "1px solid var(--line)" }}
+    >
+      {hasChips ? (
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {meta.wordType ? <MetaChip label="Type" value={meta.wordType} /> : null}
+          {meta.gender ? <MetaChip label="Gender" value={meta.gender} /> : null}
+          {meta.phonetics ? <MetaChip label="Say" value={meta.phonetics} mono /> : null}
+        </div>
+      ) : null}
+
+      {hasExample ? (
+        <div
+          className={hasChips ? "mt-4" : ""}
+          style={{ textAlign: "left" }}
+        >
+          <div
+            className="mono mb-2 flex items-center gap-1.5"
+            style={{ fontSize: 10, color: "var(--muted-2)", letterSpacing: "0.14em" }}
+          >
+            <Icon name="book" size={11} />
+            EXAMPLE
+          </div>
+          {meta.example ? (
+            <p
+              className="serif"
+              style={{ fontSize: 17, lineHeight: 1.5, color: "var(--fg)" }}
+            >
+              {meta.example}
+            </p>
+          ) : null}
+          {meta.exampleTranslation ? (
+            <p
+              className="serif"
+              style={{ fontSize: 15, lineHeight: 1.5, color: "var(--muted)", marginTop: 4 }}
+            >
+              {meta.exampleTranslation}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/session/card-meta-details.tsx
+++ b/frontend/src/app/(dashboard)/session/card-meta-details.tsx
@@ -1,91 +1,114 @@
 "use client";
 
 /**
- * Review-only display of a card's optional language-learning metadata.
+ * Review-only display of a card's optional language-learning metadata, matching
+ * the Glot design language (mono phonetics, a "type · gender" grammatical row
+ * with a colored gender dot, and an italic example sentence with the target
+ * word emphasized in the accent color).
  *
- * Rendered on the answer face of the review card. Each field is independently
- * optional: a chip/section only appears when its value is present, so a card
- * without metadata renders nothing and the review flow is unchanged.
+ * Every part is independently optional: each element omits itself gracefully
+ * when its value is absent, so a card without metadata renders nothing and the
+ * review flow is unchanged.
  */
 
-import { Icon } from "@/components/glot/icon";
-import { hasCardMeta, type CardMeta } from "@/lib/cards/meta";
+import {
+  classifyGender,
+  hasGrammarMeta,
+  splitHighlight,
+  type CardMeta,
+  type GenderTone,
+} from "@/lib/cards/meta";
 
-function MetaChip({
-  label,
-  value,
-  mono = false,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
+const GENDER_DOT: Record<GenderTone, string> = {
+  masculine: "var(--info)",
+  feminine: "#c5a3ff",
+  neuter: "var(--muted)",
+  other: "var(--muted-2)",
+};
+
+const GENDER_LABEL: Record<Exclude<GenderTone, "other">, string> = {
+  masculine: "masc.",
+  feminine: "fem.",
+  neuter: "neut.",
+};
+
+function GenderPill({ gender }: { gender: string }) {
+  const tone = classifyGender(gender);
+  const label = tone === "other" ? gender : GENDER_LABEL[tone];
   return (
     <span
       className="pill outline"
-      style={{ display: "inline-flex", gap: 6, alignItems: "baseline" }}
+      style={{ fontSize: 9, padding: "1px 7px", gap: 5, display: "inline-flex", alignItems: "center" }}
     >
-      <span
-        className="mono"
-        style={{ fontSize: 9, letterSpacing: "0.12em", color: "var(--muted-2)", textTransform: "uppercase" }}
-      >
-        {label}
-      </span>
-      <span className={mono ? "mono" : undefined} style={{ color: "var(--fg)" }}>
-        {value}
-      </span>
+      <span style={{ width: 5, height: 5, borderRadius: "50%", background: GENDER_DOT[tone] }} />
+      {label}
     </span>
   );
 }
 
-export function CardMetaDetails({ meta }: { meta: CardMeta }) {
-  if (!hasCardMeta(meta)) return null;
+/** Pronunciation in mono. Renders nothing when absent. */
+export function CardPhonetic({ meta, size = 14 }: { meta: CardMeta; size?: number }) {
+  if (!meta.phonetics) return null;
+  return (
+    <span className="mono" style={{ fontSize: size, color: "var(--muted)" }}>
+      {meta.phonetics}
+    </span>
+  );
+}
 
-  const hasChips = Boolean(meta.wordType || meta.gender || meta.phonetics);
-  const hasExample = Boolean(meta.example || meta.exampleTranslation);
+/** Grammatical row: phonetics, then "type · gender". Renders only what exists. */
+export function CardGrammar({ meta }: { meta: CardMeta }) {
+  if (!hasGrammarMeta(meta)) return null;
+
+  const hasWordMeta = Boolean(meta.wordType || meta.gender);
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2" style={{ marginTop: 10 }}>
+      <CardPhonetic meta={meta} size={14} />
+      {hasWordMeta ? (
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+          {meta.wordType ? (
+            <span style={{ fontSize: 13, color: "var(--muted)" }}>{meta.wordType}</span>
+          ) : null}
+          {meta.wordType && meta.gender ? (
+            <span style={{ color: "var(--muted-2)" }}>·</span>
+          ) : null}
+          {meta.gender ? <GenderPill gender={meta.gender} /> : null}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/** Example sentence (italic) with translation, set off by a hairline rule. */
+export function CardExample({ meta }: { meta: CardMeta }) {
+  if (!meta.example && !meta.exampleTranslation) return null;
 
   return (
     <div
-      className="w-full max-w-xl mt-6 pt-5"
-      style={{ borderTop: "1px solid var(--line)" }}
+      className="w-full max-w-xl mt-7 pt-5"
+      style={{ borderTop: "1px solid var(--line)", textAlign: "center" }}
     >
-      {hasChips ? (
-        <div className="flex flex-wrap items-center justify-center gap-2">
-          {meta.wordType ? <MetaChip label="Type" value={meta.wordType} /> : null}
-          {meta.gender ? <MetaChip label="Gender" value={meta.gender} /> : null}
-          {meta.phonetics ? <MetaChip label="Say" value={meta.phonetics} mono /> : null}
-        </div>
-      ) : null}
-
-      {hasExample ? (
-        <div
-          className={hasChips ? "mt-4" : ""}
-          style={{ textAlign: "left" }}
+      {meta.example ? (
+        <p
+          className="serif"
+          style={{ fontStyle: "italic", fontSize: 17, lineHeight: 1.6, color: "var(--fg-1)" }}
         >
-          <div
-            className="mono mb-2 flex items-center gap-1.5"
-            style={{ fontSize: 10, color: "var(--muted-2)", letterSpacing: "0.14em" }}
-          >
-            <Icon name="book" size={11} />
-            EXAMPLE
-          </div>
-          {meta.example ? (
-            <p
-              className="serif"
-              style={{ fontSize: 17, lineHeight: 1.5, color: "var(--fg)" }}
-            >
-              {meta.example}
-            </p>
-          ) : null}
-          {meta.exampleTranslation ? (
-            <p
-              className="serif"
-              style={{ fontSize: 15, lineHeight: 1.5, color: "var(--muted)", marginTop: 4 }}
-            >
-              {meta.exampleTranslation}
-            </p>
-          ) : null}
-        </div>
+          {splitHighlight(meta.example, meta.exampleHighlight).map((seg, i) =>
+            seg.highlight ? (
+              <span key={i} style={{ color: "var(--accent)", fontStyle: "normal" }}>
+                {seg.text}
+              </span>
+            ) : (
+              <span key={i}>{seg.text}</span>
+            ),
+          )}
+        </p>
+      ) : null}
+      {meta.exampleTranslation ? (
+        <p style={{ fontSize: 14, color: "var(--muted)", marginTop: 6 }}>
+          {meta.exampleTranslation}
+        </p>
       ) : null}
     </div>
   );

--- a/frontend/src/app/(dashboard)/session/page.tsx
+++ b/frontend/src/app/(dashboard)/session/page.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { cardsApi, type Card } from "@/lib/api/cards";
 import { decksApi, type Deck } from "@/lib/api/decks";
 import { readCardMeta } from "@/lib/cards/meta";
-import { CardMetaDetails } from "./card-meta-details";
+import { CardExample, CardGrammar, CardPhonetic } from "./card-meta-details";
 import { getSessionProgress } from "./session-progress";
 import { advanceQueue, shouldRequeue, type Rating } from "./session-queue";
 import { clearSessionSeed, getOrCreateSessionSeed } from "./session-seed";
@@ -60,6 +60,7 @@ export default function SessionPage() {
   const isSubmittingRef = useRef(false);
 
   const currentCard = queue[0];
+  const currentMeta = useMemo(() => readCardMeta(currentCard?.meta_data), [currentCard]);
   const deckById = useMemo(() => new Map(decks.map((deck) => [deck.id, deck])), [decks]);
   const currentDeck = currentCard?.deck_id ? deckById.get(currentCard.deck_id) : undefined;
   const { cardNumber, totalCards, progressPercent, estimatedMinutes } = getSessionProgress({
@@ -272,6 +273,11 @@ export default function SessionPage() {
                   <h2 className="serif" style={{ fontSize: "clamp(36px, 6vw, 64px)", fontWeight: 500, lineHeight: 1.1, letterSpacing: "-0.03em", color: "var(--fg)" }}>
                     {formatContent(currentCard.front_content)}
                   </h2>
+                  {currentMeta.phonetics ? (
+                    <div style={{ marginTop: 16 }}>
+                      <CardPhonetic meta={currentMeta} size={16} />
+                    </div>
+                  ) : null}
                   <div className="mt-auto pt-8 mono flex items-center gap-2" style={{ fontSize: 11, color: "var(--muted)", letterSpacing: "0.08em" }}>
                     TAP OR PRESS <kbd>SPACE</kbd>
                   </div>
@@ -279,13 +285,14 @@ export default function SessionPage() {
 
                 <div className="absolute inset-0 backface-hidden rotate-y-180 glot-card flex flex-col items-center justify-center p-10 text-center" style={{ background: "var(--surface)", borderColor: "color-mix(in oklab, var(--accent) 35%, var(--line))", boxShadow: "0 30px 80px -40px var(--accent-glow)" }}>
                   <div className="mono mb-4" style={{ fontSize: 11, color: "var(--accent)", letterSpacing: "0.16em" }}>ANSWER</div>
-                  <h3 className="serif" style={{ fontSize: 28, fontWeight: 500, color: "var(--accent)", marginBottom: 16 }}>
+                  <h3 className="serif" style={{ fontSize: 28, fontWeight: 500, color: "var(--accent)", marginBottom: 8 }}>
                     {formatContent(currentCard.front_content)}
                   </h3>
-                  <p className="serif whitespace-pre-line max-w-xl" style={{ fontSize: 19, lineHeight: 1.5, color: "var(--fg)", fontWeight: 400 }}>
+                  <CardGrammar meta={currentMeta} />
+                  <p className="serif whitespace-pre-line max-w-xl" style={{ fontSize: 19, lineHeight: 1.5, color: "var(--fg)", fontWeight: 400, marginTop: 16 }}>
                     {formatContent(currentCard.back_content)}
                   </p>
-                  <CardMetaDetails meta={readCardMeta(currentCard.meta_data)} />
+                  <CardExample meta={currentMeta} />
                 </div>
               </div>
             </div>

--- a/frontend/src/app/(dashboard)/session/page.tsx
+++ b/frontend/src/app/(dashboard)/session/page.tsx
@@ -7,6 +7,8 @@ import { Icon } from "@/components/glot/icon";
 import { cn } from "@/lib/utils";
 import { cardsApi, type Card } from "@/lib/api/cards";
 import { decksApi, type Deck } from "@/lib/api/decks";
+import { readCardMeta } from "@/lib/cards/meta";
+import { CardMetaDetails } from "./card-meta-details";
 import { getSessionProgress } from "./session-progress";
 import { advanceQueue, shouldRequeue, type Rating } from "./session-queue";
 import { clearSessionSeed, getOrCreateSessionSeed } from "./session-seed";
@@ -283,6 +285,7 @@ export default function SessionPage() {
                   <p className="serif whitespace-pre-line max-w-xl" style={{ fontSize: 19, lineHeight: 1.5, color: "var(--fg)", fontWeight: 400 }}>
                     {formatContent(currentCard.back_content)}
                   </p>
+                  <CardMetaDetails meta={readCardMeta(currentCard.meta_data)} />
                 </div>
               </div>
             </div>

--- a/frontend/src/lib/cards/meta.test.ts
+++ b/frontend/src/lib/cards/meta.test.ts
@@ -1,12 +1,18 @@
 /**
- * Tests for the review-card language-metadata normalizer.
+ * Tests for the review-card language-metadata helpers.
  *
  * Run with: `bun test src/lib/cards/meta.test.ts`
  */
 
 import { describe, expect, test } from "bun:test";
 
-import { hasCardMeta, readCardMeta } from "./meta";
+import {
+  classifyGender,
+  hasCardMeta,
+  hasGrammarMeta,
+  readCardMeta,
+  splitHighlight,
+} from "./meta";
 
 describe("readCardMeta", () => {
   test("maps snake_case backend keys to the typed shape", () => {
@@ -16,6 +22,7 @@ describe("readCardMeta", () => {
       gender: "masculine",
       example: "Le chat dort.",
       example_translation: "The cat sleeps.",
+      example_highlight: "chat",
     });
 
     expect(meta).toEqual({
@@ -24,6 +31,7 @@ describe("readCardMeta", () => {
       gender: "masculine",
       example: "Le chat dort.",
       exampleTranslation: "The cat sleeps.",
+      exampleHighlight: "chat",
     });
   });
 
@@ -52,14 +60,72 @@ describe("readCardMeta", () => {
   });
 });
 
-describe("hasCardMeta", () => {
-  test("is false when no recognized fields are present", () => {
+describe("hasCardMeta / hasGrammarMeta", () => {
+  test("hasCardMeta is false when no recognized fields are present", () => {
     expect(hasCardMeta(readCardMeta({}))).toBe(false);
     expect(hasCardMeta(readCardMeta({ reading: "ねこ" }))).toBe(false);
   });
 
-  test("is true when at least one recognized field is present", () => {
+  test("hasCardMeta is true when at least one recognized field is present", () => {
     expect(hasCardMeta(readCardMeta({ gender: "feminine" }))).toBe(true);
-    expect(hasCardMeta(readCardMeta({ phonetics: "/ʃa/" }))).toBe(true);
+    expect(hasCardMeta(readCardMeta({ example: "Le chat dort." }))).toBe(true);
+  });
+
+  test("hasGrammarMeta only considers phonetics/type/gender", () => {
+    expect(hasGrammarMeta(readCardMeta({ phonetics: "/ʃa/" }))).toBe(true);
+    expect(hasGrammarMeta(readCardMeta({ word_type: "noun" }))).toBe(true);
+    expect(hasGrammarMeta(readCardMeta({ gender: "fem" }))).toBe(true);
+    // Example-only metadata is not a grammatical detail.
+    expect(hasGrammarMeta(readCardMeta({ example: "Le chat dort." }))).toBe(false);
+  });
+});
+
+describe("classifyGender", () => {
+  test("recognizes masculine forms and abbreviations", () => {
+    for (const v of ["m", "masc", "masculine", "der", "MASCULIN"]) {
+      expect(classifyGender(v)).toBe("masculine");
+    }
+  });
+
+  test("recognizes feminine and neuter forms", () => {
+    expect(classifyGender("f")).toBe("feminine");
+    expect(classifyGender("Feminine")).toBe("feminine");
+    expect(classifyGender("neuter")).toBe("neuter");
+    expect(classifyGender("das")).toBe("neuter");
+  });
+
+  test("falls back to 'other' for unrecognized values", () => {
+    expect(classifyGender("common")).toBe("other");
+    expect(classifyGender("animate")).toBe("other");
+  });
+});
+
+describe("splitHighlight", () => {
+  test("returns one plain segment when no term is given", () => {
+    expect(splitHighlight("Le chat dort.")).toEqual([
+      { text: "Le chat dort.", highlight: false },
+    ]);
+  });
+
+  test("marks a case-insensitive occurrence of the term", () => {
+    expect(splitHighlight("Le Chat dort.", "chat")).toEqual([
+      { text: "Le ", highlight: false },
+      { text: "Chat", highlight: true },
+      { text: " dort.", highlight: false },
+    ]);
+  });
+
+  test("marks every occurrence", () => {
+    expect(splitHighlight("aube et aube", "aube")).toEqual([
+      { text: "aube", highlight: true },
+      { text: " et ", highlight: false },
+      { text: "aube", highlight: true },
+    ]);
+  });
+
+  test("returns the original text when the term is not found", () => {
+    expect(splitHighlight("Le chat dort.", "zzz")).toEqual([
+      { text: "Le chat dort.", highlight: false },
+    ]);
   });
 });

--- a/frontend/src/lib/cards/meta.test.ts
+++ b/frontend/src/lib/cards/meta.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the review-card language-metadata normalizer.
+ *
+ * Run with: `bun test src/lib/cards/meta.test.ts`
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { hasCardMeta, readCardMeta } from "./meta";
+
+describe("readCardMeta", () => {
+  test("maps snake_case backend keys to the typed shape", () => {
+    const meta = readCardMeta({
+      phonetics: "/ʃa/",
+      word_type: "noun",
+      gender: "masculine",
+      example: "Le chat dort.",
+      example_translation: "The cat sleeps.",
+    });
+
+    expect(meta).toEqual({
+      phonetics: "/ʃa/",
+      wordType: "noun",
+      gender: "masculine",
+      example: "Le chat dort.",
+      exampleTranslation: "The cat sleeps.",
+    });
+  });
+
+  test("returns an empty object for missing/empty metadata", () => {
+    expect(readCardMeta({})).toEqual({});
+    expect(readCardMeta(null)).toEqual({});
+    expect(readCardMeta(undefined)).toEqual({});
+  });
+
+  test("drops empty, whitespace, and non-string values", () => {
+    const meta = readCardMeta({
+      phonetics: "   ",
+      word_type: "",
+      gender: 42,
+      example: null,
+      example_translation: "  The cat sleeps.  ",
+    });
+
+    expect(meta).toEqual({ exampleTranslation: "The cat sleeps." });
+  });
+
+  test("ignores unrelated metadata keys", () => {
+    const meta = readCardMeta({ reading: "ねこ", word_type: "noun" });
+
+    expect(meta).toEqual({ wordType: "noun" });
+  });
+});
+
+describe("hasCardMeta", () => {
+  test("is false when no recognized fields are present", () => {
+    expect(hasCardMeta(readCardMeta({}))).toBe(false);
+    expect(hasCardMeta(readCardMeta({ reading: "ねこ" }))).toBe(false);
+  });
+
+  test("is true when at least one recognized field is present", () => {
+    expect(hasCardMeta(readCardMeta({ gender: "feminine" }))).toBe(true);
+    expect(hasCardMeta(readCardMeta({ phonetics: "/ʃa/" }))).toBe(true);
+  });
+});

--- a/frontend/src/lib/cards/meta.ts
+++ b/frontend/src/lib/cards/meta.ts
@@ -13,12 +13,14 @@ export interface CardMeta {
   phonetics?: string;
   /** Part of speech, e.g. noun, verb, adjective, adverb. */
   wordType?: string;
-  /** Grammatical gender, e.g. masculine, feminine, neuter. */
+  /** Grammatical gender, e.g. masculine, feminine, neuter (free text). */
   gender?: string;
   /** Example sentence using the word/phrase. */
   example?: string;
   /** Translation of the example sentence. */
   exampleTranslation?: string;
+  /** Substring of the example to emphasize (usually the target word). */
+  exampleHighlight?: string;
 }
 
 /** Read a trimmed, non-empty string field from a metadata bag, else undefined. */
@@ -43,12 +45,14 @@ export function readCardMeta(meta: Record<string, unknown> | null | undefined): 
   const gender = readString(meta, "gender");
   const example = readString(meta, "example");
   const exampleTranslation = readString(meta, "example_translation");
+  const exampleHighlight = readString(meta, "example_highlight");
 
   if (phonetics) result.phonetics = phonetics;
   if (wordType) result.wordType = wordType;
   if (gender) result.gender = gender;
   if (example) result.example = example;
   if (exampleTranslation) result.exampleTranslation = exampleTranslation;
+  if (exampleHighlight) result.exampleHighlight = exampleHighlight;
 
   return result;
 }
@@ -62,4 +66,56 @@ export function hasCardMeta(meta: CardMeta): boolean {
       meta.example ||
       meta.exampleTranslation,
   );
+}
+
+/** Whether any inline grammatical detail (phonetics/type/gender) is present. */
+export function hasGrammarMeta(meta: CardMeta): boolean {
+  return Boolean(meta.phonetics || meta.wordType || meta.gender);
+}
+
+export type GenderTone = "masculine" | "feminine" | "neuter" | "other";
+
+/**
+ * Classify a free-text grammatical gender so the UI can pick a consistent
+ * accent dot and short label. Accepts common forms and abbreviations
+ * (e.g. "m", "masc", "masculine", "der") across a few languages; anything
+ * unrecognized falls back to "other" and is displayed verbatim.
+ */
+export function classifyGender(value: string): GenderTone {
+  const v = value.trim().toLowerCase();
+  if (/^(m|masc|masculine|masculin|männlich|der|el|il|le)\b/.test(v)) return "masculine";
+  if (/^(f|fem|feminine|féminin|weiblich|die|la)\b/.test(v)) return "feminine";
+  if (/^(n|neut|neuter|neutral|sächlich|das)\b/.test(v)) return "neuter";
+  return "other";
+}
+
+export interface HighlightSegment {
+  text: string;
+  highlight: boolean;
+}
+
+/**
+ * Split `text` into ordered segments, marking case-insensitive occurrences of
+ * `term` for emphasis. Returns a single non-highlighted segment when `term` is
+ * empty or not found, so callers can always render the segments directly.
+ */
+export function splitHighlight(text: string, term?: string): HighlightSegment[] {
+  const needle = term?.trim();
+  if (!needle) return [{ text, highlight: false }];
+
+  const segments: HighlightSegment[] = [];
+  const lowerText = text.toLowerCase();
+  const lowerNeedle = needle.toLowerCase();
+  let cursor = 0;
+
+  for (;;) {
+    const index = lowerText.indexOf(lowerNeedle, cursor);
+    if (index === -1) break;
+    if (index > cursor) segments.push({ text: text.slice(cursor, index), highlight: false });
+    segments.push({ text: text.slice(index, index + needle.length), highlight: true });
+    cursor = index + needle.length;
+  }
+
+  if (cursor < text.length) segments.push({ text: text.slice(cursor), highlight: false });
+  return segments.length > 0 ? segments : [{ text, highlight: false }];
 }

--- a/frontend/src/lib/cards/meta.ts
+++ b/frontend/src/lib/cards/meta.ts
@@ -1,0 +1,65 @@
+/**
+ * Optional language-learning fields a card may carry inside its free-form
+ * `meta_data`. These are surfaced only in the review/session UI and are always
+ * optional — a card without them reviews exactly as before.
+ *
+ * The backend stores these inside the card's `meta_data` JSONB (documented by
+ * the `CardMetadata` schema). Mirroring them here keeps the review UI's contract
+ * explicit while tolerating arbitrary/legacy metadata shapes.
+ */
+
+export interface CardMeta {
+  /** Pronunciation / phonetic transcription (e.g. IPA). */
+  phonetics?: string;
+  /** Part of speech, e.g. noun, verb, adjective, adverb. */
+  wordType?: string;
+  /** Grammatical gender, e.g. masculine, feminine, neuter. */
+  gender?: string;
+  /** Example sentence using the word/phrase. */
+  example?: string;
+  /** Translation of the example sentence. */
+  exampleTranslation?: string;
+}
+
+/** Read a trimmed, non-empty string field from a metadata bag, else undefined. */
+function readString(meta: Record<string, unknown>, key: string): string | undefined {
+  const value = meta[key];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Normalize a card's raw `meta_data` into the recognized language-learning
+ * fields. Non-string and empty/whitespace values are dropped so the review UI
+ * can simply check for presence before rendering a chip/row/section.
+ */
+export function readCardMeta(meta: Record<string, unknown> | null | undefined): CardMeta {
+  if (!meta || typeof meta !== "object") return {};
+
+  const result: CardMeta = {};
+  const phonetics = readString(meta, "phonetics");
+  const wordType = readString(meta, "word_type");
+  const gender = readString(meta, "gender");
+  const example = readString(meta, "example");
+  const exampleTranslation = readString(meta, "example_translation");
+
+  if (phonetics) result.phonetics = phonetics;
+  if (wordType) result.wordType = wordType;
+  if (gender) result.gender = gender;
+  if (example) result.example = example;
+  if (exampleTranslation) result.exampleTranslation = exampleTranslation;
+
+  return result;
+}
+
+/** Whether any recognized language-learning field is present. */
+export function hasCardMeta(meta: CardMeta): boolean {
+  return Boolean(
+    meta.phonetics ||
+      meta.wordType ||
+      meta.gender ||
+      meta.example ||
+      meta.exampleTranslation,
+  );
+}


### PR DESCRIPTION
## Summary

Adds optional **language-learning fields** to the review-card experience — and only there. When a card provides them, the review/session card now shows:

- **Phonetics / pronunciation** — mono, shown on both the prompt and answer faces
- **Word type** (noun, verb, adjective, adverb, …)
- **Grammatical gender** — a small pill with a colored dot (masculine = blue, feminine = violet, neuter = muted), classified from free-text gender
- **Example sentence** — italic serif with the target word emphasized in the accent color, plus a muted **translation**

Each field renders independently; if a value is absent or empty, its chip/row/section is hidden. The normal review flow is untouched: flip, rate buttons, keyboard shortcuts, progress, and requeue behavior all behave exactly as before.

The visual treatment recreates the **Glot design bundle** (Claude Design handoff): mono phonetics, a `type · gender` grammatical row with a colored gender dot, and an italic accent-highlighted example sentence with translation.

This keeps Glot focused as a **language-learning** tool rather than a generic card app, surfacing the details a learner wants at recall time.

## Backend (minimal & compatible)

These fields live in the card's existing free-form `meta_data` JSONB — the established "type-specific fields (vocab readings, etc.)" plumbing — so:

- **No DB migration**, no schema/column churn.
- Fields are **fully optional** and **never required** for existing cards.
- They **pass through** create/read unchanged when provided.

A new `CardMetadata` Pydantic schema documents the recognized optional keys (`phonetics`, `word_type`, `gender`, `example`, `example_translation`, `example_highlight`) with `extra="allow"` so unrelated existing metadata is preserved.

## Frontend (surgical)

- `readCardMeta()` — pure normalizer mapping snake_case backend keys to a typed shape, dropping empty/whitespace/non-string values.
- `classifyGender()` / `splitHighlight()` — pure, unit-tested helpers for the gender dot/label and accent highlighting of the example's target word.
- `CardPhonetic` / `CardGrammar` / `CardExample` — **review-only** components using the existing Glot design system (mono, pills, serif). Each renders nothing when its data is absent.
- Only `session/page.tsx` is wired up. No other screens or flows were changed.

## Tests

- **Backend** (`tests/test_card_metadata.py`, 5 tests): optional defaults, language-field parsing (incl. `example_highlight`), preservation of unrelated keys, create/read passthrough.
- **Frontend** (`src/lib/cards/meta.test.ts`): key mapping, empty/non-string dropping, `hasCardMeta`/`hasGrammarMeta`, `classifyGender` across languages/abbreviations, and `splitHighlight` (case-insensitive, multi-occurrence, not-found).

### Checks run
- Backend: `pytest` — all collectable tests pass (incl. 5 new). *(3 pre-existing collection errors in `test_db_engine_config` / `test_extraction_worker_context` / `test_resources_download` come from a malformed `cors_origins` in the local `.env`, unrelated to this change.)*
- Frontend: `bun test` (59 pass), `tsc` (no errors in production code), `eslint` (0 errors), `bun run build` (success).

## Caveats / scope notes

- Entry/editing of these fields in the create/edit-card forms is intentionally **out of scope** — values flow through the existing `meta_data` plumbing. This PR only adds review-time display + the documented backend shape.
- `gender` is stored as free text; the UI classifies common forms/abbreviations (incl. fr/de/es/it) for the dot + short label and shows anything unrecognized verbatim.
- Untouched as required: Docker/infra/deploy files, `Glot UI Redesign/`, and the local `backend/scripts/seed.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)