### PR TITLE
chore(infra): timestamp production deploy steps

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -88,13 +88,14 @@ for i in $(seq 1 30); do
   fi
   if [ "$i" -eq 30 ]; then
     log "  ✗ Backend health check failed after 30 attempts"
+    break
   fi
   sleep 2
 done
 
 if [ "$HEALTH_OK" = "false" ]; then
   log "  ✗ Deploy failed — backend unhealthy"
-  docker compose -f "$COMPOSE_FILE" logs --tail=50 backend
+  docker compose -f "$COMPOSE_FILE" logs --tail=50 backend || true
   fail_step
   # Do not rollback: alembic already migrated the DB, old code may conflict
   # with the new schema.  Leave containers down and alert.
@@ -112,13 +113,14 @@ for i in $(seq 1 15); do
   fi
   if [ "$i" -eq 15 ]; then
     log "  ✗ Frontend health check failed after 15 attempts"
+    break
   fi
   sleep 2
 done
 
 if [ "$FRONTEND_OK" = "false" ]; then
   log "  ✗ Deploy failed — frontend unhealthy"
-  docker compose -f "$COMPOSE_FILE" logs --tail=50 frontend
+  docker compose -f "$COMPOSE_FILE" logs --tail=50 frontend || true
   fail_step
   exit 1
 fi
@@ -127,7 +129,7 @@ finish_step
 start_step "[8/9] Health check worker"
 if ! docker compose -f "$COMPOSE_FILE" ps --status running --services 2>/dev/null | grep -q '^worker$'; then
   log "  ✗ Worker not running"
-  docker compose -f "$COMPOSE_FILE" logs --tail=50 worker
+  docker compose -f "$COMPOSE_FILE" logs --tail=50 worker || true
   fail_step
   exit 1
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,9 +6,48 @@ COMPOSE_FILE="$DEPLOY_DIR/docker-compose.prod.yml"
 
 cd "$DEPLOY_DIR"
 
+# Timestamped logs are printed to stdout so GitHub Actions captures them from
+# the remote SSH deploy step.
+timestamp() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+log() {
+  echo "$(timestamp) $*"
+}
+
+DEPLOY_STARTED_AT=$(date +%s)
+STEP_STARTED_AT=$DEPLOY_STARTED_AT
+CURRENT_STEP="deploy initialization"
+
+finish_step() {
+  local finished_at
+  finished_at=$(date +%s)
+  log "✓ ${CURRENT_STEP} complete duration=$((finished_at - STEP_STARTED_AT))s"
+}
+
+fail_step() {
+  local failed_at
+  failed_at=$(date +%s)
+  log "✗ ${CURRENT_STEP} failed duration=$((failed_at - STEP_STARTED_AT))s total=$((failed_at - DEPLOY_STARTED_AT))s"
+}
+
+start_step() {
+  CURRENT_STEP="$1"
+  STEP_STARTED_AT=$(date +%s)
+  log "${CURRENT_STEP} started"
+}
+
+on_error() {
+  local status=$?
+  fail_step
+  exit "$status"
+}
+trap on_error ERR
+
 # Prevent concurrent deploys
 exec 9>/tmp/glot-deploy.lock
-flock -n 9 || { echo "Deploy already in progress — aborting"; exit 1; }
+flock -n 9 || { log "Deploy already in progress — aborting"; exit 1; }
 
 # Validate required env vars before doing anything
 : "${REGISTRY_TOKEN:?must be set in environment}"
@@ -17,75 +56,88 @@ flock -n 9 || { echo "Deploy already in progress — aborting"; exit 1; }
 # Falls back to :latest if not set
 export GLOT_VERSION="${GLOT_VERSION:-latest}"
 
-echo "=== Glot Deploy (version: $GLOT_VERSION) ==="
+log "=== Glot Deploy started version=$GLOT_VERSION ==="
 
-echo "[1/9] Logging in to GHCR..."
+start_step "[1/9] Logging in to GHCR"
 echo "$REGISTRY_TOKEN" | docker login ghcr.io -u hsilabot --password-stdin
+finish_step
 
-echo "[2/9] Pulling images (tag: $GLOT_VERSION)..."
+start_step "[2/9] Pulling images tag=$GLOT_VERSION"
 docker compose -f "$COMPOSE_FILE" pull
+finish_step
 
-echo "[3/9] Stopping and removing old containers..."
+start_step "[3/9] Stopping and removing old containers"
 docker compose -f "$COMPOSE_FILE" down --remove-orphans
+finish_step
 
-echo "[4/9] Running database migrations..."
+start_step "[4/9] Running database migrations"
 docker compose -f "$COMPOSE_FILE" run --rm backend uv run alembic upgrade head
+finish_step
 
-echo "[5/9] Starting services..."
+start_step "[5/9] Starting services"
 docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
+finish_step
 
-echo "[6/9] Health check (backend)..."
+start_step "[6/9] Health check backend"
 HEALTH_OK=false
 for i in $(seq 1 30); do
   if curl -sf http://127.0.0.1:8000/docs > /dev/null 2>&1; then
-    echo "  ✓ Backend is healthy"
+    log "  ✓ Backend is healthy attempt=$i"
     HEALTH_OK=true
     break
   fi
   if [ "$i" -eq 30 ]; then
-    echo "  ✗ Backend health check failed after 30 attempts"
+    log "  ✗ Backend health check failed after 30 attempts"
   fi
   sleep 2
 done
 
 if [ "$HEALTH_OK" = "false" ]; then
-  echo "  ✗ Deploy failed — backend unhealthy"
+  log "  ✗ Deploy failed — backend unhealthy"
   docker compose -f "$COMPOSE_FILE" logs --tail=50 backend
+  fail_step
   # Do not rollback: alembic already migrated the DB, old code may conflict
   # with the new schema.  Leave containers down and alert.
   exit 1
 fi
+finish_step
 
-echo "[7/9] Health check (frontend)..."
+start_step "[7/9] Health check frontend"
 FRONTEND_OK=false
 for i in $(seq 1 15); do
   if curl -sf http://127.0.0.1:3000 > /dev/null 2>&1; then
-    echo "  ✓ Frontend is healthy"
+    log "  ✓ Frontend is healthy attempt=$i"
     FRONTEND_OK=true
     break
   fi
   if [ "$i" -eq 15 ]; then
-    echo "  ✗ Frontend health check failed after 15 attempts"
+    log "  ✗ Frontend health check failed after 15 attempts"
   fi
   sleep 2
 done
 
 if [ "$FRONTEND_OK" = "false" ]; then
-  echo "  ✗ Deploy failed — frontend unhealthy"
+  log "  ✗ Deploy failed — frontend unhealthy"
   docker compose -f "$COMPOSE_FILE" logs --tail=50 frontend
+  fail_step
   exit 1
 fi
+finish_step
 
-echo "[8/9] Health check (worker)..."
+start_step "[8/9] Health check worker"
 if ! docker compose -f "$COMPOSE_FILE" ps --status running --services 2>/dev/null | grep -q '^worker$'; then
-  echo "  ✗ Worker not running"
+  log "  ✗ Worker not running"
   docker compose -f "$COMPOSE_FILE" logs --tail=50 worker
+  fail_step
   exit 1
 fi
-echo "  ✓ Worker is running"
+log "  ✓ Worker is running"
+finish_step
 
-echo "[9/9] Cleaning old images and build cache..."
+start_step "[9/9] Cleaning old images and build cache"
 docker image prune -a -f
 docker builder prune -f
+finish_step
 
-echo "=== Deploy complete ==="
+DEPLOY_FINISHED_AT=$(date +%s)
+log "=== Deploy complete version=$GLOT_VERSION total=$((DEPLOY_FINISHED_AT - DEPLOY_STARTED_AT))s ==="


### PR DESCRIPTION
## Summary

Adds timestamped production deploy logging to `scripts/deploy.sh`.

- Print UTC timestamps for each deploy log line.
- Record start/completion for all 9 server-side deploy stages.
- Include per-step `duration=<seconds>s` on success.
- Include failed-step duration and total elapsed time on errors.
- Print total deploy duration at the end.

Because the deploy workflow streams this script over SSH, these logs will appear directly in the GitHub Actions `Deploy` step output.

## Test Plan

- `bash -n scripts/deploy.sh`
- `git diff --check -- scripts/deploy.sh`

## Scope

No deployment behavior changes: only logging/timing output.
