### PR TITLE
fix(deploy): keep production deploy running after DB migrations

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -71,7 +71,12 @@ docker compose -f "$COMPOSE_FILE" down --remove-orphans
 finish_step
 
 start_step "[4/9] Running database migrations"
-docker compose -f "$COMPOSE_FILE" run --rm backend uv run alembic upgrade head
+# -T disables pseudo-TTY allocation and, crucially, prevents `run` from
+# attaching to stdin. This script is streamed to the remote shell as stdin
+# (`bash < scripts/deploy.sh`); without -T, `docker compose run` consumes the
+# remainder of the script, so bash never reads the steps below and services
+# are never restarted.
+docker compose -f "$COMPOSE_FILE" run -T --rm backend uv run alembic upgrade head
 finish_step
 
 start_step "[5/9] Starting services"


### PR DESCRIPTION
## Problem / root cause

The v0.3.0 release deploy pulled images and stopped the old containers, then ran migrations with:

```sh
docker compose -f "$COMPOSE_FILE" run --rm backend uv run alembic upgrade head
```

The deploy script is streamed to the server-side shell over SSH as stdin:

```sh
ssh ... "GLOT_VERSION=$GLOT_VERSION REGISTRY_TOKEN='***'" bash < scripts/deploy.sh
```

By default `docker compose run` attaches to stdin. Because bash's stdin *is* the deploy script, `run` consumed the remainder of `scripts/deploy.sh`. bash never read the steps after the migration, so **services were never restarted** even though the workflow reported success.

## Fix

Add `-T` to the migration command so `docker compose run` does not allocate a TTY or attach to stdin:

```sh
docker compose -f "$COMPOSE_FILE" run -T --rm backend uv run alembic upgrade head
```

This leaves the script's stdin intact for bash to keep reading. A comment was added explaining why stdin must not be attached here. Scope is limited to `scripts/deploy.sh`.

## Test plan

- `bash -n scripts/deploy.sh` — syntax OK
- `git diff --check -- scripts/deploy.sh` — no whitespace errors
- Next release deploy should proceed through steps [5/9]-[9/9] (start services, health checks, cleanup) and log `=== Deploy complete ===`.

## Impact / risk

Low. `-T` only changes stdin/TTY handling for the migration container; `alembic upgrade head` needs no interactive input. No behavioral change to the migration itself. Restores the intended post-migration deploy steps.