### PR TITLE
fix(session): adapt review keyboard hints for touch devices

### DIFF
--- a/frontend/src/app/(dashboard)/session/page.tsx
+++ b/frontend/src/app/(dashboard)/session/page.tsx
@@ -278,8 +278,9 @@ export default function SessionPage() {
                       <CardPhonetic meta={currentMeta} size={16} />
                     </div>
                   ) : null}
-                  <div className="mt-auto pt-8 mono flex items-center gap-2" style={{ fontSize: 11, color: "var(--muted)", letterSpacing: "0.08em" }}>
-                    TAP OR PRESS <kbd>SPACE</kbd>
+                  <div className="mt-auto pt-8 mono flex items-center justify-center gap-2" style={{ fontSize: 11, color: "var(--muted)", letterSpacing: "0.08em" }}>
+                    <span className="touch-only">TAP TO FLIP</span>
+                    <span className="kbd-only">TAP OR PRESS <kbd>SPACE</kbd></span>
                   </div>
                 </div>
 
@@ -320,7 +321,7 @@ export default function SessionPage() {
                       >
                         <span style={{ fontSize: 14 }}>{btn.label}</span>
                         <span className="mono" style={{ fontSize: 10, opacity: 0.75, letterSpacing: "0.04em" }}>{btn.description}</span>
-                        <kbd style={{ marginTop: 4, background: "rgba(0,0,0,0.15)", color: "inherit", border: "1px solid rgba(0,0,0,0.15)" }}>{btn.shortcut}</kbd>
+                        <kbd className="kbd-only" style={{ marginTop: 4, background: "rgba(0,0,0,0.15)", color: "inherit", border: "1px solid rgba(0,0,0,0.15)" }}>{btn.shortcut}</kbd>
                       </button>
                     );
                   })}
@@ -330,7 +331,7 @@ export default function SessionPage() {
               <div className="flex justify-center">
                 <Button size="lg" className="px-12 gap-2" onClick={handleFlip} disabled={isSubmitting}>
                   Show answer
-                  <kbd style={{ background: "rgba(0,0,0,0.15)", color: "inherit", border: "1px solid rgba(0,0,0,0.2)" }}>SPACE</kbd>
+                  <kbd className="kbd-only" style={{ background: "rgba(0,0,0,0.15)", color: "inherit", border: "1px solid rgba(0,0,0,0.2)" }}>SPACE</kbd>
                 </Button>
               </div>
             ) : null}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -249,6 +249,19 @@ kbd {
   color: var(--fg-1);
 }
 
+/* Keyboard shortcut hints are only useful on devices with a physical
+   keyboard, so gate them on a precise pointer + hover (a real mouse).
+   Touch and tablet layouts get touch-first wording instead — this keys
+   off input capability rather than viewport width, so a wide tablet is
+   still treated as touch. Keyboard handlers stay active regardless, so
+   shortcuts keep working anywhere a keyboard is attached. */
+.kbd-only { display: none; }
+.touch-only { display: inline-flex; align-items: center; }
+@media (hover: hover) and (pointer: fine) {
+  .kbd-only { display: inline-flex; align-items: center; gap: 6px; }
+  .touch-only { display: none; }
+}
+
 /* Big numerals */
 .numeral {
   font-family: var(--serif);


### PR DESCRIPTION
## Summary

Review-session keyboard hints (the `SPACE` flip prompt and the `1/2/3/4` rating keycaps) are only useful with a physical keyboard, but they were rendered on every layout — poor UX on mobile/tablet/touch-first devices.

This gates the hints behind a `(hover: hover) and (pointer: fine)` media query using two small reusable utilities (`.kbd-only` / `.touch-only`):

- **Desktop (precise pointer + hover):** unchanged — full hints (`TAP OR PRESS SPACE`, `Show answer` + `SPACE`, `1/2/3/4` keycaps).
- **Touch / tablet:** keycaps are hidden and the flip prompt shows touch-first wording (`TAP TO FLIP`).

Keying off **input capability** rather than viewport width means a wide tablet is still correctly treated as touch (a width breakpoint would not). Keyboard event handlers are untouched, so shortcuts keep working anywhere a keyboard is attached — including touch laptops.

## Changes
- `frontend/src/app/globals.css` — add `.kbd-only` / `.touch-only` utilities + media query.
- `frontend/src/app/(dashboard)/session/page.tsx` — apply the utilities to the three hint sites.

## Testing
- `bun test` → 124 pass, 0 fail.
- `bun run lint` → 0 errors (only pre-existing warnings, none in changed lines).

Tests are pure API/logic (the project has no DOM render environment, as noted in `session.test.ts`), so this presentational/CSS change has no unit test added; behavior is verified via lint and responsive media-query breakpoints.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
