### PR TITLE
fix(frontend): recenter content when sidebar collapses

### DIFF
--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -1,19 +1,31 @@
+"use client";
+
+import * as React from "react";
 import { Sidebar } from "./sidebar";
 import { BottomNav } from "./bottom-nav";
 import { Header } from "./header";
+import { cn } from "@/lib/utils";
 
 interface AppShellProps {
   children: React.ReactNode;
 }
 
 export function AppShell({ children }: AppShellProps) {
+  const [collapsed, setCollapsed] = React.useState(false);
+
   return (
     <div className="min-h-screen bg-background">
       {/* Desktop Sidebar */}
-      <Sidebar />
+      <Sidebar collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
 
-      {/* Main Content Area */}
-      <div className="md:pl-64 lg:pl-72 flex flex-col h-screen overflow-hidden">
+      {/* Main Content Area — offset matches the sidebar width so collapsing
+          recenters the content. Mobile (< md) has no offset; bottom-nav owns it. */}
+      <div
+        className={cn(
+          "flex flex-col h-screen overflow-hidden transition-[padding] duration-200 ease-[ease]",
+          collapsed ? "md:pl-16" : "md:pl-60"
+        )}
+      >
         <Header />
         <main className="flex-1 overflow-y-auto p-4 md:p-6 lg:p-8 pb-20 md:pb-8">
           {children}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -23,12 +23,16 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/library", label: "Library", icon: "library" },
 ];
 
-export function Sidebar() {
+interface SidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const pathname = usePathname();
-  const [collapsed, setCollapsed] = React.useState(false);
   const { user } = useAuth();
 
-  const width = collapsed ? 64 : 240;
+  const width = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_EXPANDED_WIDTH;
 
   const initials = React.useMemo(() => {
     if (!user) return "G";
@@ -148,7 +152,7 @@ export function Sidebar() {
       <button
         aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
         title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-        onClick={() => setCollapsed(!collapsed)}
+        onClick={onToggle}
         style={{
           position: "fixed",
           left: width,
@@ -266,4 +270,5 @@ export function Sidebar() {
   );
 }
 
-export const SIDEBAR_DEFAULT_WIDTH = 240;
+export const SIDEBAR_EXPANDED_WIDTH = 240;
+export const SIDEBAR_COLLAPSED_WIDTH = 64;


### PR DESCRIPTION
## Summary

Fixes #96: collapsing the sidebar now recenters the main content on tablet/desktop layouts instead of leaving it pushed to the right.

Previously the sidebar owned its own `collapsed` state and only changed its own width, while `AppShell` used a static `md:pl-64 lg:pl-72` offset. Collapsing visually shrank the sidebar but left the content offset unchanged.

## Changes

- Lift `collapsed` state into `AppShell` so the sidebar and the main-content offset share a single source of truth. `Sidebar` now takes `collapsed` / `onToggle` props.
- Drive the content offset from that state: `md:pl-60` expanded and `md:pl-16` collapsed, with a padding transition matching the sidebar animation.
- Keep the offset only at `md` and up so mobile bottom-nav layout is unchanged.

## Verification

- `bun run lint` → 0 errors; existing unrelated warnings only.
- `bun test` → 124 pass, 0 fail.
- `tsc --noEmit` → pre-existing test-file errors only; none in changed source files.

Closes #96