### PR TITLE
fix(frontend): simplify deck card due count layout

### DIFF
--- a/frontend/src/app/(dashboard)/decks/page.tsx
+++ b/frontend/src/app/(dashboard)/decks/page.tsx
@@ -475,7 +475,7 @@ function DeckRowCard({
           onOpen();
         }
       }}
-      className="relative cursor-pointer group overflow-hidden"
+      className="relative cursor-pointer group overflow-hidden flex flex-col"
       style={{
         padding: "24px 24px 22px",
         borderRadius: 16,
@@ -506,8 +506,8 @@ function DeckRowCard({
         }}
       />
 
-      {/* Top row: language tag + due pill */}
-      <div className="flex justify-between items-start">
+      {/* Top row: language tag + card count */}
+      <div className="flex items-start">
         <span
           className="mono"
           style={{ fontSize: 10, color: "var(--muted)", letterSpacing: "0.14em" }}
@@ -517,30 +517,12 @@ function DeckRowCard({
             : "DECK"}{" "}
           · {total}
         </span>
-        {due > 0 && (
-          <div
-            className="mono"
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 4,
-              padding: "3px 8px",
-              borderRadius: 999,
-              background: "var(--accent)",
-              color: "var(--accent-fg)",
-              fontSize: 11,
-              fontWeight: 600,
-            }}
-          >
-            {due} due
-          </div>
-        )}
       </div>
 
       {/* Deck name + description */}
       <div style={{ marginTop: 28 }}>
         <div
-          className="serif"
+          className="serif line-clamp-2"
           style={{
             fontSize: 26,
             fontWeight: 500,
@@ -551,6 +533,7 @@ function DeckRowCard({
           {deck.name}
         </div>
         <div
+          className="line-clamp-2"
           style={{ fontSize: 13, color: "var(--muted)", marginTop: 6, lineHeight: 1.4 }}
         >
           {deck.description || "No description"}
@@ -604,7 +587,7 @@ function DeckRowCard({
       </div>
 
       {/* Progress bar at bottom */}
-      <div style={{ position: "absolute", left: 24, right: 24, bottom: 22 }}>
+      <div style={{ marginTop: "auto", paddingTop: 16 }}>
         <div
           className="mono"
           style={{


### PR DESCRIPTION
## Summary

Fixes the duplicated/crowded due count on deck cards (Issue #97).

Deck cards previously showed the due count in two places — a top-right yellow badge and a lower stats pill. The top badge competed with metadata like `FRENCH · 77`, causing wrapping at iPhone-sized widths, and long descriptions could push the lower stats into the absolutely-positioned mastery footer.

## Changes

- **Remove the redundant top-right due badge.** Due/new now live only in the lower stats pills.
- **Clamp the deck name and description to two lines** (`line-clamp-2`) so long text can't grow the card unbounded.
- **Lay the card out as a flex column** with the progress bar in normal flow (`marginTop: auto`) instead of absolute positioning, so stats can never collide with the mastery label/progress bar regardless of description length.

The fix is surgical — only `decks/page.tsx`'s `DeckRowCard` is touched; no unrelated UI was redesigned.

## Verification

- `bun run lint` — no new warnings (only pre-existing unused-var/`<img>` warnings remain)
- `bun test` — 124 pass, 0 fail
- `bun run build` — production build succeeds
- Typecheck errors are limited to pre-existing `bun:test` module resolution in `.test.ts` files; the changed file is clean.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)