### PR TITLE
fix(frontend): load custom fonts reliably

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4,7 +4,9 @@
 @custom-variant dark (&:is([data-theme="dark"] *));
 
 /* ===== Glot redesign — dark-first, bold gen-z AI startup ===== */
-@import url('https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Inter+Tight:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+/* Fonts are loaded via next/font/google in app/layout.tsx, which exposes the
+   --font-crimson-pro / --font-inter-tight / --font-jetbrains-mono variables
+   consumed by --serif / --sans / --mono below. */
 
 /* Dark theme — default */
 :root,
@@ -31,9 +33,9 @@
   --bad: #ff7a7a;
   --info: #88c0ff;
 
-  --serif: 'Crimson Pro', 'Times New Roman', serif;
-  --sans: 'Inter Tight', system-ui, sans-serif;
-  --mono: 'JetBrains Mono', ui-monospace, monospace;
+  --serif: var(--font-crimson-pro), 'Crimson Pro', Georgia, serif;
+  --sans: var(--font-inter-tight), 'Inter Tight', system-ui, sans-serif;
+  --mono: var(--font-jetbrains-mono), 'JetBrains Mono', ui-monospace, monospace;
 
   --radius-sm: 4px;
   --radius: 8px;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,8 +1,31 @@
 import type { Metadata, Viewport } from "next";
+import { Crimson_Pro, Inter_Tight, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { AuthProvider } from "@/components/providers/auth-provider";
 import { Toaster } from "@/components/ui/sonner";
+
+// Load custom fonts through next/font so they are self-hosted and registered
+// reliably, instead of a CSS @import that is fragile to ordering and runtime
+// loading. The generated CSS variables are wired into --serif/--sans/--mono.
+const crimsonPro = Crimson_Pro({
+  subsets: ["latin"],
+  style: ["normal", "italic"],
+  display: "swap",
+  variable: "--font-crimson-pro",
+});
+
+const interTight = Inter_Tight({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter-tight",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-jetbrains-mono",
+});
 
 export const metadata: Metadata = {
   title: "Glot — Remember anything, in minutes a day",
@@ -35,7 +58,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning data-theme="dark" data-accent="lime" data-density="regular">
+    <html
+      lang="en"
+      suppressHydrationWarning
+      data-theme="dark"
+      data-accent="lime"
+      data-density="regular"
+      className={`${crimsonPro.variable} ${interTight.variable} ${jetbrainsMono.variable}`}
+    >
       <head>
         <script dangerouslySetInnerHTML={{ __html: tweaksScript }} />
       </head>


### PR DESCRIPTION
## Problem

Custom fonts were not loading (Issue #101). In `frontend/src/app/globals.css` the Google Fonts `@import url(...)` was placed **after** `@import "tailwindcss"`, `@import "tw-animate-css"`, and `@custom-variant`. CSS requires `@import` to precede all rules except `@charset`/`@layer`, so:

- `bun run build` warned: *"@import rules must precede all rules aside from @charset and @layer statements"*
- `bun run dev` hard-failed with a 500 / CSS parse error
- No `@font-face` rules loaded, `document.fonts` was empty, and serif text fell back to Times New Roman because Crimson Pro never loaded.

## Fix

Load the three fonts via `next/font/google` in `app/layout.tsx` instead of a CSS `@import`. They are now self-hosted, automatically preloaded, and emitted as proper `@font-face` rules with no fragile import ordering. The generated CSS variables are wired into the existing `--serif` / `--sans` / `--mono` tokens, so `.serif`, `.mono`, `.font-serif`, `.numeral`, and body styles keep working unchanged. Families are preserved: Crimson Pro, Inter Tight, JetBrains Mono.

## Verification

- `bun run lint` — 0 errors (only pre-existing unrelated warnings)
- `bun test` — 124 pass, 0 fail
- `bun run build` — succeeds; the `@import` ordering warning is **gone**
- Built/served via standalone server and inspected the served HTML/CSS:
  - Fonts preloaded in `<head>` (`rel="preload" ... as="font"`)
  - Real `@font-face` rules with self-hosted woff2 sources for Crimson Pro (incl. italic), Inter Tight, and JetBrains Mono
  - Tokens resolve to `--serif: var(--font-crimson-pro), 'Crimson Pro', Georgia, serif` etc.
  - The only remaining `Times New Roman` reference is next/font's metric-adjusted `local(Times New Roman)` fallback (anti-CLS), shown only briefly during `swap` while Crimson Pro loads — Crimson Pro now actually loads.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)