### PR TITLE
fix(extraction): remove idle recovery polling

### DIFF
--- a/backend/app/api/v1/resources.py
+++ b/backend/app/api/v1/resources.py
@@ -14,6 +14,7 @@ Endpoints:
     GET    /resources/{id}/progress  - Get extraction progress
 """
 
+from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -34,9 +35,95 @@ from app.schemas.resource import (
     UploadRequest,
     UploadResponse,
 )
-from app.services import StorageService
+from app.services import RedisService, StorageService
 
 router = APIRouter()
+
+# Statuses that can have an in-flight extraction worth probing Redis for.
+_ACTIVE_EXTRACTION_STATUSES = (
+    ExtractionStatus.PENDING,
+    ExtractionStatus.PROCESSING,
+)
+
+
+# A progress signal older than the worker timeout is no longer evidence of
+# active work. Keep a small buffer over WorkerSettings.job_timeout (20 min).
+_ACTIVE_PROGRESS_MAX_AGE = timedelta(minutes=25)
+
+
+def _has_recent_progress_signal(progress: dict | None) -> bool:
+    """Return True when Redis progress is recent enough to count as active."""
+    if not progress:
+        return False
+
+    updated_at = progress.get("updated_at")
+    if not updated_at:
+        return False
+
+    try:
+        updated = datetime.fromisoformat(str(updated_at))
+    except ValueError:
+        return False
+
+    if updated.tzinfo is None:
+        updated = updated.replace(tzinfo=UTC)
+
+    return datetime.now(UTC) - updated <= _ACTIVE_PROGRESS_MAX_AGE
+
+
+def _recovery_flags(
+    status: ExtractionStatus,
+    progress: dict | None,
+) -> tuple[bool, bool]:
+    """Compute (extraction_problem, can_resume_extraction) for one resource.
+
+    DB status is the source of truth; ``progress`` is only a Redis liveness
+    signal. Missing or stale progress means there is no active signal:
+    - FAILED: a problem the user can retry.
+    - PENDING/PROCESSING without a recent progress signal: interrupted/stale
+      and resumable (the worker likely restarted; there is no cron to recover it).
+    - PENDING/PROCESSING with a recent progress signal: actively running, no problem.
+    - NONE/COMPLETED: nothing to recover.
+    """
+    if status == ExtractionStatus.FAILED:
+        return True, True
+    if status in _ACTIVE_EXTRACTION_STATUSES:
+        if not _has_recent_progress_signal(progress):
+            return True, True
+        return False, False
+    return False, False
+
+
+async def _attach_recovery_state(items: list[tuple[ResourceRead, Resource]]) -> None:
+    """Populate recovery flags for resources already in this request scope.
+
+    Only the resources being returned are evaluated (no global DB/queue scan).
+    Redis is consulted purely as a progress/liveness signal, never as truth.
+    """
+    needs_redis = any(
+        res.extraction_status in _ACTIVE_EXTRACTION_STATUSES for _, res in items
+    )
+
+    redis: RedisService | None = None
+    try:
+        if needs_redis:
+            redis = RedisService(get_settings().redis_url)
+            await redis.connect()
+
+        for read, res in items:
+            progress: dict | None = None
+            if redis is not None and res.extraction_status in _ACTIVE_EXTRACTION_STATUSES:
+                try:
+                    progress = await redis.get_progress(res.id)
+                except Exception:
+                    progress = None
+            read.extraction_problem, read.can_resume_extraction = _recovery_flags(
+                res.extraction_status,
+                progress,
+            )
+    finally:
+        if redis is not None:
+            await redis.close()
 
 
 def _build_resource_read(
@@ -285,10 +372,12 @@ async def list_my_resources(
     result = await session.execute(query)
     rows = result.all()
 
-    items = [
-        _build_resource_read(resource, user_resource, current_user.id)
+    reads_with_resources = [
+        (_build_resource_read(resource, user_resource, current_user.id), resource)
         for resource, user_resource in rows
     ]
+    await _attach_recovery_state(reads_with_resources)
+    items = [read for read, _ in reads_with_resources]
 
     return ResourceListResponse(items=items, total=total, limit=limit, offset=offset)
 
@@ -387,7 +476,7 @@ async def get_resource(
         )
 
     name = user_resource.name if user_resource else resource.file_name
-    return ResourceRead(
+    read = ResourceRead(
         id=resource.id,
         content_hash=resource.content_hash,
         name=name,
@@ -399,6 +488,12 @@ async def get_resource(
         processed_at=resource.processed_at,
         is_owner=resource.uploaded_by == current_user.id,
     )
+
+    # Only library resources can be resumed by this user; skip recovery probe otherwise.
+    if user_resource is not None:
+        await _attach_recovery_state([(read, resource)])
+
+    return read
 
 
 @router.post("/{resource_id}/add", response_model=ResourceRead, status_code=201)
@@ -685,8 +780,6 @@ async def get_extraction_progress(
         ExtractionStatus.PROCESSING,
     ]:
         try:
-            from app.services import RedisService
-
             redis = RedisService(get_settings().redis_url)
             await redis.connect()
             progress_data = await redis.get_progress(resource_id)
@@ -725,8 +818,13 @@ async def trigger_extraction(
 
     This is idempotent - calling multiple times will:
     - For new extraction: render pages and queue all page jobs
-    - For incomplete: queue only incomplete pages
+    - For incomplete/interrupted (Resume): queue only incomplete pages
     - For completed: return error (already done)
+
+    This same endpoint backs the frontend "Resume" action for interrupted or
+    failed extractions: it re-queues only incomplete work via the idempotent
+    prepare_extraction job. A deterministic ARQ job id dedupes concurrent
+    triggers so a double click cannot double-queue.
 
     Returns 202 Accepted - extraction runs in background.
     """
@@ -767,12 +865,24 @@ async def trigger_extraction(
 
     await session.commit()
 
-    # Enqueue prepare_extraction job (handles rendering + page job queueing)
-    from app.services import RedisService
-
+    # Enqueue prepare_extraction job (handles rendering + page job queueing).
+    # Deterministic job id dedupes concurrent Extract/Resume triggers.
     settings = get_settings()
     redis = RedisService(settings.redis_url)
-    job_id = await redis.enqueue_job("prepare_extraction", resource_id)
+    job_id = await redis.enqueue_job(
+        "prepare_extraction",
+        resource_id,
+        _job_id=f"glot:prepare:{resource_id}",
+    )
+    # Mark this resource as intentionally queued so a quick refresh does not
+    # look interrupted before the worker has written its first progress update.
+    await redis.set_progress(
+        resource_id,
+        status="pending",
+        progress=0,
+        current_page=None,
+        total_pages=resource.page_count,
+    )
     await redis.close()
 
     return {

--- a/backend/app/schemas/resource.py
+++ b/backend/app/schemas/resource.py
@@ -58,6 +58,19 @@ class ResourceRead(BaseModel):
     processed_at: datetime | None
     is_owner: bool = Field(..., description="Whether current user is the uploader")
 
+    # Cronless recovery state (computed per-request, not stored).
+    extraction_problem: bool = Field(
+        default=False,
+        description=(
+            "True when extraction is incomplete/stale with no active progress "
+            "signal (e.g. interrupted by a worker restart). UI shows an amber warning."
+        ),
+    )
+    can_resume_extraction: bool = Field(
+        default=False,
+        description="True when the user can re-queue incomplete/failed extraction work.",
+    )
+
     model_config = {"from_attributes": True}
 
 

--- a/backend/app/services/redis_service.py
+++ b/backend/app/services/redis_service.py
@@ -7,6 +7,7 @@ Provides a unified interface for Redis operations including:
 - General caching
 """
 
+from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlparse
 
@@ -160,6 +161,7 @@ class RedisService:
             mapping["error"] = error
 
         if mapping:
+            mapping["updated_at"] = datetime.now(UTC).isoformat()
             await pool.hset(key, mapping=mapping)
             await pool.expire(key, expire_seconds)
 
@@ -187,6 +189,7 @@ class RedisService:
             "current_page": int(data.get(b"current_page", 0)) or None,
             "total_pages": int(data.get(b"total_pages", 0)) or None,
             "error": data.get(b"error", b"").decode() or None,
+            "updated_at": data.get(b"updated_at", b"").decode() or None,
         }
 
     async def clear_progress(self, resource_id: int) -> None:

--- a/backend/app/workers/extraction_worker.py
+++ b/backend/app/workers/extraction_worker.py
@@ -4,9 +4,13 @@ Extraction workers for ARQ background jobs.
 Architecture:
 - prepare_extraction: Coordinator job (ensure metadata, render missing PNGs, queue page jobs)
 - extract_page: Processes a single page (atomic, retryable)
-- check_stale_extractions: Cron job to re-queue stuck pages
-- check_orphan_resources: Cron job to fix resources stuck in PROCESSING
+- check_stale_extractions: Re-queue stuck pages (run at worker startup)
+- check_orphan_resources: Fix resources stuck in PROCESSING (run at worker startup)
 - recover_incomplete_extractions: Startup recovery for incomplete processing resources
+
+Recovery is cronless: there is no periodic DB polling. Recovery runs once at
+worker startup, and otherwise on-demand when the frontend resumes a resource
+(see resources API). Deterministic ARQ job ids dedupe re-queued work.
 
 Run with:
     arq app.workers.extraction_worker.WorkerSettings
@@ -16,7 +20,6 @@ import io
 from datetime import timedelta
 
 import fitz  # PyMuPDF
-from arq.cron import cron
 from loguru import logger
 from PIL import Image
 from sqlalchemy import func, select
@@ -28,6 +31,16 @@ from app.db import async_session_factory
 from app.models import PageExtraction, PageStatus, Resource
 from app.models.resource import ExtractionStatus
 from app.services import RedisService, StorageService
+
+
+def _prepare_job_id(resource_id: int) -> str:
+    """Deterministic ARQ job id for a resource's prepare job (dedupe signal)."""
+    return f"glot:prepare:{resource_id}"
+
+
+def _extract_page_job_id(resource_id: int, page_number: int) -> str:
+    """Deterministic ARQ job id for a single page job (dedupe signal)."""
+    return f"glot:extract:{resource_id}:{page_number}"
 
 
 async def _render_page_to_temp(
@@ -264,6 +277,7 @@ async def prepare_extraction(ctx: dict, resource_id: int) -> dict:
                     "extract_page",
                     resource_id,
                     page.page_number,
+                    _job_id=_extract_page_job_id(resource_id, page.page_number),
                 )
                 if job_id:
                     queued += 1
@@ -500,7 +514,7 @@ async def _update_resource_progress(
 
 async def check_stale_extractions(ctx: dict):
     """
-    Cron job: Find stuck extractions and re-queue them.
+    Recovery helper: find stuck extractions and re-queue them.
 
     A page is considered stuck if:
     - Status is PROCESSING
@@ -535,6 +549,7 @@ async def check_stale_extractions(ctx: dict):
                     "extract_page",
                     page.resource_id,
                     page.page_number,
+                    _job_id=_extract_page_job_id(page.resource_id, page.page_number),
                 )
                 if job_id:
                     requeued += 1
@@ -554,7 +569,7 @@ async def check_stale_extractions(ctx: dict):
 
 async def check_orphan_resources(ctx: dict):
     """
-    Cron job: Fix resources stuck in PROCESSING when all pages are done.
+    Recovery helper: fix resources stuck in PROCESSING when all pages are done.
 
     This can happen if a worker crashes between updating page statuses
     and updating the parent resource status.
@@ -674,6 +689,7 @@ async def recover_incomplete_extractions(ctx: dict):
                 job_id = await redis.enqueue_job(
                     "prepare_extraction",
                     resource.id,
+                    _job_id=_prepare_job_id(resource.id),
                 )
                 if job_id:
                     recovered += 1
@@ -739,13 +755,13 @@ class WorkerSettings:
     functions = [prepare_extraction, extract_page]
     on_startup = on_worker_startup
     on_shutdown = on_worker_shutdown
-    cron_jobs = [
-        cron(check_stale_extractions, minute={0, 15, 30, 45}),
-        cron(check_orphan_resources, minute={5, 20, 35, 50}),
-    ]
+    # No cron_jobs: recovery is cronless (runs at startup + on-demand resume).
+    # This avoids periodic DB polling while the queue is idle.
     redis_settings = _get_worker_redis_settings()
     queue_name = "glot:extraction_queue"
     max_jobs = 4
+    # Per-job retry/timeout bounds. Jobs are idempotent, so retries are safe.
+    max_tries = 3
     job_timeout = 1200
     keep_result = 0
     health_check_interval = 600

--- a/backend/tests/test_extraction_recovery.py
+++ b/backend/tests/test_extraction_recovery.py
@@ -1,0 +1,266 @@
+"""
+Tests for cronless extraction recovery.
+
+Covers:
+- WorkerSettings has no periodic cron_jobs (no idle DB polling) and keeps
+  retry/timeout bounds.
+- Per-resource recovery flag computation (_recovery_flags).
+- _attach_recovery_state only probes Redis within the request scope and never
+  treats Redis as truth.
+- The extract/resume endpoint re-queues via the idempotent prepare_extraction
+  job using a deterministic (dedupe) job id.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.api.v1 import resources as resources_api
+from app.api.v1.resources import (
+    _attach_recovery_state,
+    _recovery_flags,
+    trigger_extraction,
+)
+from app.models import Resource, User, UserResource
+from app.models.resource import ExtractionStatus
+from app.schemas.resource import ResourceRead
+from app.workers import extraction_worker
+from app.workers.extraction_worker import WorkerSettings
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+def _make_resource(status: ExtractionStatus, resource_id: int = 1) -> Resource:
+    return Resource(
+        id=resource_id,
+        content_hash="a" * 64,
+        size_bytes=123,
+        page_count=3,
+        file_name="doc.pdf",
+        is_public=False,
+        extraction_status=status,
+        uploaded_by=1,
+    )
+
+
+def _make_read(status: ExtractionStatus, resource_id: int = 1) -> ResourceRead:
+    return ResourceRead(
+        id=resource_id,
+        content_hash="a" * 64,
+        name="doc",
+        size_bytes=123,
+        page_count=3,
+        is_public=False,
+        extraction_status=status,
+        uploaded_at="2025-01-01T00:00:00Z",
+        processed_at=None,
+        is_owner=True,
+    )
+
+
+# --- WorkerSettings: cronless + retry/timeout bounds ---
+
+
+def test_worker_settings_has_no_cron_jobs() -> None:
+    # No periodic cron jobs => no idle DB polling.
+    assert getattr(WorkerSettings, "cron_jobs", None) in (None, [])
+
+
+def test_worker_settings_has_retry_and_timeout_bounds() -> None:
+    assert WorkerSettings.max_tries >= 1
+    assert WorkerSettings.job_timeout > 0
+
+
+def test_startup_recovery_still_wired() -> None:
+    # Recovery functions remain available and run at startup (not via cron).
+    assert WorkerSettings.on_startup is extraction_worker.on_worker_startup
+    assert callable(extraction_worker.check_stale_extractions)
+    assert callable(extraction_worker.check_orphan_resources)
+    assert callable(extraction_worker.recover_incomplete_extractions)
+
+
+def test_deterministic_job_ids() -> None:
+    assert extraction_worker._prepare_job_id(7) == "glot:prepare:7"
+    assert extraction_worker._extract_page_job_id(7, 3) == "glot:extract:7:3"
+
+
+# --- _recovery_flags ---
+
+
+@pytest.mark.parametrize(
+    "status,progress,expected",
+    [
+        (ExtractionStatus.FAILED, None, (True, True)),
+        (ExtractionStatus.PROCESSING, None, (True, True)),  # stale, no signal
+        (ExtractionStatus.PENDING, None, (True, True)),  # stale, no signal
+        (
+            ExtractionStatus.PROCESSING,
+            {"progress": 40, "updated_at": datetime.now(UTC).isoformat()},
+            (False, False),
+        ),  # live
+        (
+            ExtractionStatus.PENDING,
+            {"progress": 0, "updated_at": datetime.now(UTC).isoformat()},
+            (False, False),
+        ),  # live
+        (
+            ExtractionStatus.PROCESSING,
+            {
+                "progress": 40,
+                "updated_at": (datetime.now(UTC) - timedelta(minutes=30)).isoformat(),
+            },
+            (True, True),
+        ),  # stale signal
+        (ExtractionStatus.NONE, None, (False, False)),
+        (ExtractionStatus.COMPLETED, None, (False, False)),
+    ],
+)
+def test_recovery_flags(status, progress, expected) -> None:
+    assert _recovery_flags(status, progress) == expected
+
+
+# --- _attach_recovery_state ---
+
+
+@pytest.mark.asyncio
+async def test_attach_recovery_state_flags_stale_processing(monkeypatch) -> None:
+    read = _make_read(ExtractionStatus.PROCESSING)
+    resource = _make_resource(ExtractionStatus.PROCESSING)
+
+    class FakeRedis:
+        def __init__(self, _url):
+            pass
+
+        async def connect(self):
+            return None
+
+        async def get_progress(self, _id):
+            return None  # no active progress signal -> stale
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(resources_api, "RedisService", FakeRedis)
+
+    await _attach_recovery_state([(read, resource)])
+
+    assert read.extraction_problem is True
+    assert read.can_resume_extraction is True
+
+
+@pytest.mark.asyncio
+async def test_attach_recovery_state_live_processing(monkeypatch) -> None:
+    read = _make_read(ExtractionStatus.PROCESSING)
+    resource = _make_resource(ExtractionStatus.PROCESSING)
+
+    class FakeRedis:
+        def __init__(self, _url):
+            pass
+
+        async def connect(self):
+            return None
+
+        async def get_progress(self, _id):
+            return {"progress": 50, "updated_at": datetime.now(UTC).isoformat()}
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(resources_api, "RedisService", FakeRedis)
+
+    await _attach_recovery_state([(read, resource)])
+
+    assert read.extraction_problem is False
+    assert read.can_resume_extraction is False
+
+
+@pytest.mark.asyncio
+async def test_attach_recovery_state_skips_redis_when_no_active(monkeypatch) -> None:
+    read = _make_read(ExtractionStatus.COMPLETED)
+    resource = _make_resource(ExtractionStatus.COMPLETED)
+
+    def _boom(_url):
+        raise AssertionError("Redis must not be contacted for non-active resources")
+
+    monkeypatch.setattr(resources_api, "RedisService", _boom)
+
+    await _attach_recovery_state([(read, resource)])
+
+    assert read.extraction_problem is False
+    assert read.can_resume_extraction is False
+
+
+# --- extract/resume endpoint re-queues via prepare_extraction (dedupe id) ---
+
+
+@pytest.mark.asyncio
+async def test_trigger_extraction_requeues_with_deterministic_job_id(monkeypatch) -> None:
+    resource = _make_resource(ExtractionStatus.PROCESSING, resource_id=5)
+    current_user = User(
+        id=1,
+        email="user@example.com",
+        password_hash="hashed",
+        is_active=True,
+    )
+    user_resource = UserResource(user_id=1, resource_id=5, name="doc")
+
+    session = AsyncMock()
+    session.get.return_value = resource
+    session.execute.return_value = _ScalarResult(user_resource)
+
+    enqueue_calls = []
+    progress_calls = []
+
+    class FakeRedis:
+        def __init__(self, _url):
+            pass
+
+        async def enqueue_job(self, fn, *args, **kwargs):
+            enqueue_calls.append((fn, args, kwargs))
+            return "job-123"
+
+        async def set_progress(self, resource_id, **kwargs):
+            progress_calls.append((resource_id, kwargs))
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(resources_api, "RedisService", FakeRedis)
+    monkeypatch.setattr(
+        resources_api,
+        "get_settings",
+        lambda: Mock(redis_url="redis://example"),
+    )
+
+    result = await trigger_extraction(
+        resource_id=5,
+        session=session,
+        current_user=current_user,
+    )
+
+    assert result["resource_id"] == 5
+    assert result["job_id"] == "job-123"
+    assert len(enqueue_calls) == 1
+    fn, args, kwargs = enqueue_calls[0]
+    assert fn == "prepare_extraction"
+    assert args == (5,)
+    # Deterministic dedupe id, not ARQ queue introspection.
+    assert kwargs.get("_job_id") == "glot:prepare:5"
+    assert progress_calls == [
+        (
+            5,
+            {
+                "status": "pending",
+                "progress": 0,
+                "current_page": None,
+                "total_pages": 3,
+            },
+        )
+    ]

--- a/frontend/src/components/resources/resource-card.tsx
+++ b/frontend/src/components/resources/resource-card.tsx
@@ -89,23 +89,32 @@ export function ResourceCard({
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
 
+  // Interrupted/stale extraction (or hard failure): backend asks us to offer Resume.
+  const isInterrupted =
+    resource.extraction_problem === true || resource.extraction_status === "failed";
+
   const canExtract =
     isMyLibrary &&
-    (resource.extraction_status === "none" || resource.extraction_status === "failed");
-  
-  const isFailed = resource.extraction_status === "failed";
-  const isExtracting = resource.extraction_status === "pending" || resource.extraction_status === "processing";
+    (resource.extraction_status === "none" ||
+      isInterrupted ||
+      resource.can_resume_extraction === true);
+
+  // Only spin/show progress for live extractions, not interrupted ones.
+  const isExtracting =
+    !isInterrupted &&
+    (resource.extraction_status === "pending" ||
+      resource.extraction_status === "processing");
   const progressValue = extractionProgress ?? (resource.extraction_status === "pending" ? 0 : undefined);
 
   // Status indicator config
   const getStatusConfig = () => {
-    // Check for paused state first (failed or stalled processing)
-    if (resource.extraction_status === "failed") {
+    // Interrupted/stale/failed extraction shows an amber warning + Resume.
+    if (isInterrupted) {
       return {
         icon: PauseCircle,
         color: "text-amber-500",
         borderColor: "hover:border-amber-500/50",
-        label: "Paused",
+        label: "Interrupted",
       };
     }
 
@@ -197,7 +206,7 @@ export function ResourceCard({
                 <div className="flex gap-2">
                   {isMyLibrary && canExtract && (
                     <Button
-                      variant={isFailed ? "destructive" : "outline"}
+                      variant="outline"
                       size="sm"
                       className="cursor-pointer transition-all hover:scale-105 hover:shadow-lg hover:shadow-primary/50 hover:brightness-110"
                       onClick={(e) => {
@@ -206,7 +215,7 @@ export function ResourceCard({
                       }}
                     >
                       <Sparkles className="h-3.5 w-3.5 mr-1" />
-                      {isFailed ? "Resume" : "Extract"}
+                      {isInterrupted ? "Resume" : "Extract"}
                     </Button>
                   )}
                   {!isMyLibrary && (

--- a/frontend/src/components/resources/resource-detail-modal.tsx
+++ b/frontend/src/components/resources/resource-detail-modal.tsx
@@ -132,19 +132,23 @@ export function ResourceDetailModal({
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
 
+  // Interrupted/stale extraction (or hard failure): backend asks us to offer Resume.
+  const isInterrupted =
+    resource.extraction_problem === true || resource.extraction_status === "failed";
+
   const getExtractionStatus = () => {
     const status = resource.extraction_status;
     const progressValue =
       extractionProgress ?? (status === "pending" ? 0 : undefined);
 
-    // Check for paused state
-    if (status === "failed") {
+    // Interrupted/stale/failed extraction shows an amber warning + Resume.
+    if (isInterrupted) {
       return {
         icon: PauseCircle,
         color: "text-amber-500",
         bgColor: "bg-amber-50 dark:bg-amber-950/20",
         borderColor: "border-amber-200 dark:border-amber-800",
-        label: "Paused",
+        label: "Interrupted",
         canExtract: true,
       };
     }
@@ -312,7 +316,7 @@ export function ResourceDetailModal({
                   onClick={handleExtract}
                 >
                   <Sparkles className="h-4 w-4 mr-2" />
-                  {resource.extraction_status === "failed" ? "Resume" : "Extract"}
+                  {isInterrupted ? "Resume" : "Extract"}
                 </Button>
               )}
 

--- a/frontend/src/lib/api/resources.test.ts
+++ b/frontend/src/lib/api/resources.test.ts
@@ -96,6 +96,28 @@ describe("resourcesApi.getMyResources", () => {
       "Failed to fetch resources",
     );
   });
+
+  test("surfaces per-resource recovery flags", async () => {
+    fetchMock.enqueue(() =>
+      jsonResponse({
+        items: [
+          makeResource({
+            extraction_status: "processing",
+            extraction_problem: true,
+            can_resume_extraction: true,
+          }),
+        ],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      }),
+    );
+
+    const r = await resourcesApi.getMyResources();
+
+    expect(r.items[0].extraction_problem).toBe(true);
+    expect(r.items[0].can_resume_extraction).toBe(true);
+  });
 });
 
 describe("resourcesApi.getPublicResources", () => {

--- a/frontend/src/lib/api/resources.ts
+++ b/frontend/src/lib/api/resources.ts
@@ -17,6 +17,11 @@ export interface Resource {
   uploaded_at: string;
   processed_at: string | null;
   is_owner: boolean;
+  // Cronless recovery state, computed per-request by the backend.
+  // extraction_problem: extraction is interrupted/stale (show amber warning).
+  // can_resume_extraction: user can re-queue incomplete/failed work.
+  extraction_problem?: boolean;
+  can_resume_extraction?: boolean;
 }
 
 export interface ResourceListResponse {


### PR DESCRIPTION
## Summary
- remove ARQ cron jobs that poll Postgres while idle
- preserve Redis/ARQ and startup recovery
- add per-resource recovery flags and Resume path
- reuse existing frontend status/button UI for interrupted extraction

## Verification
- backend targeted tests: 21 passed
- backend ruff: passed
- frontend resource API tests: 16 passed
- frontend eslint: 0 errors, existing image warnings only
- typecheck: changed source files clean; pre-existing bun:test test-file errors remain