### PR TITLE
fix(backend): cascade card deletion to review logs

### DIFF
--- a/backend/alembic/versions/0005_review_logs_cascade.py
+++ b/backend/alembic/versions/0005_review_logs_cascade.py
@@ -1,0 +1,47 @@
+"""cascade review_logs on card delete
+
+Revision ID: 0005_review_cascade
+Revises: 0004_sweep_index
+Create Date: 2026-08-20
+
+Deleting a card with review history used to fail: review_logs.card_id pointed at
+cards.id with no ON DELETE CASCADE, so the DELETE raised an IntegrityError after
+the API had already returned 204 (the session dependency commits in post-response
+teardown). Review history has no meaning without its card, so cascade it.
+
+This migration drops the existing FK constraint and re-adds it with
+ON DELETE CASCADE. The constraint was autocreated by PostgreSQL, so it follows
+the convention <table>_<column>_fkey.
+"""
+
+from alembic import op
+
+revision: str = "0005_review_logs_cascade"
+down_revision: str | None = "0004_sweep_index"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+CONSTRAINT_NAME = "review_logs_card_id_fkey"
+
+
+def upgrade() -> None:
+    op.drop_constraint(CONSTRAINT_NAME, "review_logs", type_="foreignkey")
+    op.create_foreign_key(
+        CONSTRAINT_NAME,
+        source_table="review_logs",
+        referent_table="cards",
+        local_cols=["card_id"],
+        remote_cols=["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(CONSTRAINT_NAME, "review_logs", type_="foreignkey")
+    op.create_foreign_key(
+        CONSTRAINT_NAME,
+        source_table="review_logs",
+        referent_table="cards",
+        local_cols=["card_id"],
+        remote_cols=["id"],
+    )

--- a/backend/app/models/review_log.py
+++ b/backend/app/models/review_log.py
@@ -9,7 +9,7 @@ Ownership: ReviewLogs inherit user ownership via card_id → cards.deck_id → d
 
 from datetime import datetime
 
-from sqlalchemy import Column, Index, text
+from sqlalchemy import Column, ForeignKey, Index, Integer, text
 from sqlmodel import Field, SQLModel
 
 from app.core.datetime_utils import TimestampTZ, utc_now
@@ -44,8 +44,15 @@ class ReviewLog(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     card_id: int = Field(
-        foreign_key="cards.id",
-        index=True,
+        sa_column=Column(
+            Integer,
+            # Review history has no meaning once its card is gone; deleting a
+            # card cascades to its logs so DELETE actually succeeds (previously
+            # the FK blocked deletion and the API returned a phantom 204).
+            ForeignKey("cards.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
         description="Card that was reviewed",
     )
 

--- a/backend/tests/test_delete_review_cascade.py
+++ b/backend/tests/test_delete_review_cascade.py
@@ -18,7 +18,7 @@ def test_review_log_card_fk_cascades_on_delete() -> None:
     table = ReviewLog.__table__
     fk = next(
         fk for fk in table.foreign_key_constraints
-        if list(fk.columns) == [table.c.card_id]
+        if [c.name for c in fk.columns] == ["card_id"]
     )
 
     assert fk.referred_table.name == "cards"

--- a/backend/tests/test_delete_review_cascade.py
+++ b/backend/tests/test_delete_review_cascade.py
@@ -1,0 +1,34 @@
+"""Regression tests for deleting cards with review history.
+
+Deleting a reviewed card used to fail silently: ``review_logs.card_id`` pointed
+at ``cards.id`` with no ``ON DELETE CASCADE``, so the DB DELETE raised an
+IntegrityError after the API had already returned 204 (the session dependency
+commits in post-response teardown). The card survived while the client was told
+it was gone.
+
+These tests assert the invariant that prevents the regression: the
+``review_logs → cards`` FK must cascade on delete.
+"""
+
+from app.models import ReviewLog
+
+
+def test_review_log_card_fk_cascades_on_delete() -> None:
+    """Deleting a card must cascade to its review logs (not block it)."""
+    table = ReviewLog.__table__
+    fk = next(
+        fk for fk in table.foreign_key_constraints
+        if list(fk.columns) == [table.c.card_id]
+    )
+
+    assert fk.referred_table.name == "cards"
+    assert fk.ondelete == "CASCADE"
+
+
+def test_review_log_card_id_is_indexed() -> None:
+    """The card_id column keeps its index (used by review-history lookups)."""
+    card_indexes = [
+        [c.name for c in ix.columns]
+        for ix in ReviewLog.__table__.indexes
+    ]
+    assert ["card_id"] in card_indexes, f"no index on card_id: {card_indexes}"


### PR DESCRIPTION
## Problem
`DELETE /cards/{id}` returns 204 but does not delete cards that have review history. Confirmed with phrase cards `c'est` and `se présenter`. Fixes #114.

## Root cause
- `delete_card` calls `session.delete(card)` without committing; the session dependency commits in post-response teardown, after the 204 is already sent.
- `review_logs.card_id → cards.id` has no `ON DELETE CASCADE`, so the DB DELETE raises `IntegrityError` on commit, the transaction rolls back, and the card survives while the API reported 204.
- Cards with zero review_logs delete fine, which is why this slipped through.

## Key changes
- `review_logs.card_id` FK now `ON DELETE CASCADE` (backend/app/models/review_log.py).
- Migration `0005_review_logs_cascade` alters the existing PostgreSQL constraint.
- Regression tests assert the cascade and the preserved card_id index.

## Impact / risk
- Deleting a card now permanently removes its review history (intended — logs are useless without their card).
- Low risk: single FK policy change + migration; 246 backend tests pass, Ruff clean.