### PR TITLE
fix(infra): extend deploy health-check timeout for slow cold starts

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -106,7 +106,7 @@ for i in $(seq 1 90); do
   sleep 2
 done
 
-if [ "$HEALTH_OK" = "0" ]; then
+if [ "$HEALTH_OK" != "1" ]; then
   log "  ✗ Deploy failed — backend unhealthy"
   docker compose -f "$COMPOSE_FILE" logs --tail=50 backend || true
   fail_step

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -89,20 +89,24 @@ finish_step
 
 start_step "[7/10] Health check backend"
 HEALTH_OK=false
-for i in $(seq 1 30); do
-  if curl -sf http://127.0.0.1:8000/docs > /dev/null 2>&1; then
+# The box is small (961 MB) and the Neon connection is cold on a fresh start
+# after migrations; the backend can take well over a minute to become ready.
+# Wait generously (90 attempts ~ 3 min) so a slow-but-successful startup is not
+# reported as a failed deploy. Use the real /health endpoint, not Swagger docs.
+for i in $(seq 1 90); do
+  if curl -sf http://127.0.0.1:8000/health > /dev/null 2>&1; then
     log "  ✓ Backend is healthy attempt=$i"
-    HEALTH_OK=true
+    HEALTH_OK=1
     break
   fi
-  if [ "$i" -eq 30 ]; then
-    log "  ✗ Backend health check failed after 30 attempts"
+  if [ "$i" -eq 90 ]; then
+    log "  ✗ Backend health check failed after 90 attempts"
     break
   fi
   sleep 2
 done
 
-if [ "$HEALTH_OK" = "false" ]; then
+if [ "$HEALTH_OK" = "0" ]; then
   log "  ✗ Deploy failed — backend unhealthy"
   docker compose -f "$COMPOSE_FILE" logs --tail=50 backend || true
   fail_step


### PR DESCRIPTION
## Problem
Deploys to the production server (961 MB RAM) can report a failed backend health check even when the app starts successfully.

The backend takes over a minute to become ready after a fresh deploy (cold Neon connection + small box). The deploy health check only waited ~60s (30 attempts × 2s) and then declared "Deploy failed — backend unhealthy" — a false negative. The services came up ~48s later and are healthy.

## Root cause
- deploy.sh step [7/10] looped 30 times × 2s = ~60s max wait, too short for this box's cold start.
- It probed `/docs` (Swagger) rather than the actual `/health` route.

## Key change
- Wait up to 3 minutes (90 × 2s) so a slow-but-successful startup is not reported as a failure.
- Probe the real `/health` endpoint (confirmed: `backend/app/main.py:93`, live → 200).

## Impact / risk
- Low. Deploy-time infrastructure script only; no app behavior change.